### PR TITLE
Fix: a keyword may have duplicated keys so it is not strictly a dict

### DIFF
--- a/lessons/collections.md
+++ b/lessons/collections.md
@@ -107,7 +107,7 @@ The three characteristics of keyword lists highlight their importance:
 
 + Keys are atoms.
 + Keys are ordered.
-+ Keys are unique.
++ Keys are not unique.
 
 For these reasons keywords lists are most commonly used to pass options to functions.
 


### PR DESCRIPTION
This is from Keyword help module:

A keyword may have duplicated keys so it is not strictly a dictionary. However
most of the functions in this module behave exactly as a dictionary and mimic
the API defined by the Dict behaviour.
