### PR TITLE
Fix TOC of basics/basics.md

### DIFF
--- a/lessons/basics/basics.md
+++ b/lessons/basics/basics.md
@@ -22,8 +22,8 @@ Setup, basic types and operations.
 	- [Arithmetic](#arithmetic)
 	- [Boolean](#boolean)
 	- [Comparison](#comparison)
-	- [String concatenation](#string-concatenation)
 	- [String interpolation](#string-interpolation)
+	- [String concatenation](#string-concatenation)
 
 ## Setup
 


### PR DESCRIPTION
Hi, the order of 'table of contents' in `basics/basics.md` is not the same as its contents.