### PR TITLE
Fix typos in intro lesson

### DIFF
--- a/lessons/basics/basics.md
+++ b/lessons/basics/basics.md
@@ -202,7 +202,7 @@ iex> "Hello #{name}"
 
 ### String concatenation
 
-String concatenation is uses the `<>` operator:
+String concatenation uses the `<>` operator:
 
 ```elixir
 iex> name = "Sean"

--- a/lessons/basics/collections.md
+++ b/lessons/basics/collections.md
@@ -20,7 +20,7 @@ List, tuples, keywords, maps, dicts and functional combinators.
 
 ## Lists
 
-Lists are simple collections of values, they may include multiple types; lists may include non-unqiue values:
+Lists are simple collections of values, they may include multiple types; lists may include non-unique values:
 
 ```elixir
 iex> [3.41, :pie, "Apple"]


### PR DESCRIPTION
Fixed grammar at the end of basic chapter and typo at the beginning of collections chapter.