### PR TITLE
fix small typo

### DIFF
--- a/lessons/basics/mix.md
+++ b/lessons/basics/mix.md
@@ -72,7 +72,7 @@ The `application` section is used during the generation of our application file 
 
 ## Compilation
 
-Mix is a smart and will compile your changes when necessary, but it may still be necessary explicitly compile your project.  In this section we'll cover how to compile our project and what compilation does.
+Mix is smart and will compile your changes when necessary, but it may still be necessary explicitly compile your project.  In this section we'll cover how to compile our project and what compilation does.
 
 To compile a mix project we only need to run `mix compile` in our base directory:
 


### PR DESCRIPTION
Don't know if it was a typo, or it was wanted to say that `Mix is a smart build tool...`. Just removed the `a` for brevity, but if you prefer the later, I'll update the PR :)