### PR TITLE
Add missing code for 'SimpleQueue' module - Synchronous Functions on OTP Concurrency page

### DIFF
--- a/cn/lessons/advanced/otp-concurrency.md
+++ b/cn/lessons/advanced/otp-concurrency.md
@@ -79,6 +79,7 @@ defmodule SimpleQueue do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
 
+  def queue, do: GenServer.call(__MODULE__, :queue)
   def dequeue, do: GenServer.call(__MODULE__, :dequeue)
 end
 ```

--- a/jp/lessons/advanced/otp-concurrency.md
+++ b/jp/lessons/advanced/otp-concurrency.md
@@ -81,6 +81,7 @@ defmodule SimpleQueue do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
 
+  def queue, do: GenServer.call(__MODULE__, :queue)
   def dequeue, do: GenServer.call(__MODULE__, :dequeue)
 end
 

--- a/lessons/advanced/otp-concurrency.md
+++ b/lessons/advanced/otp-concurrency.md
@@ -81,6 +81,7 @@ defmodule SimpleQueue do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
 
+  def queue, do: GenServer.call(__MODULE__, :queue)
   def dequeue, do: GenServer.call(__MODULE__, :dequeue)
 end
 


### PR DESCRIPTION
Hi guys! I was going through 'Elixir School' lessons. Great introduction to Elixir. Thanks for putting this up.

However, I noticed a small typo in code on this page http://elixirschool.com/lessons/advanced/otp-concurrency/ under 'Synchronous Functions' section. Following line was missing from code example:

```
def queue, do: GenServer.call(__MODULE__, :queue)
```

So, I updated the code. Let me know, if I'm wrong or anything like that. 