### PR TITLE
Updating Index of Portuguese(Brazil)

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,6 @@ Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [日本語][jp] a
 [es]: https://elixirschool.com/es/
 [jp]: https://elixirschool.com/jp/
 [pt]: https://elixirschool.com/pt/
-[pt]: https://elixirschool.com/pt/
 [vi]: https://elixirschool.com/vi/
 
 _Your feedback and participation is encouraged!_

--- a/pt/index.md
+++ b/pt/index.md
@@ -8,17 +8,25 @@ lang: pt
 
 As lições de fundamentos de Elixir foram inspiradas em [Scala School](http://twitter.github.io/scala_school/) do Twitter.
 
+Disponível em [English][en], [Việt ngữ][vi], [汉语][cn], [Español][es] e [日本語][jp]
+
+[en]: https://elixirschool.com/
+[cn]: https://elixirschool.com/cn/
+[es]: https://elixirschool.com/es/
+[jp]: https://elixirschool.com/jp/
+[vi]: https://elixirschool.com/vi/
+
 _Nós encorajamos a sua participação e colaboração!_
 
 ## Sobre o Elixir
 
 "Elixir é uma linguagem dinamica e funcional projetada para construir aplicações escalaveis e de facil manutenção." — [elixir-lang.org](http://elixir-lang.org/)
 
-Elixir usa a máquina virtual do Erlang para construir sistemas distribuidos e tolerantes a falhas com baixa latência.
+Elixir aproveita a massivamente testada máquina virtual do Erlang para construir sistemas distribuídos e tolerantes a falhas com baixa latência.
 
 __Características__:
 
-+ Escalavel
++ Escalável
 + Tolerante a falhas
 + Programação funcional
 + Extensível


### PR DESCRIPTION
* Removing Extra pt Link from `en` index.
* Updating `pt` index and following the `en` index format.

Related to #89 