### PR TITLE
Fixed 'specifics' numbering to reflect 'en' lesson changes

### DIFF
--- a/es/lessons/specifics/eex.md
+++ b/es/lessons/specifics/eex.md
@@ -2,7 +2,7 @@
 layout: page
 title: Elixir Embebido (EEx)
 category: specifics
-order: 4
+order: 3
 lang: es
 ---
 

--- a/es/lessons/specifics/ets.md
+++ b/es/lessons/specifics/ets.md
@@ -2,7 +2,7 @@
 layout: page
 title: Almacenamiento de términos de Erlang (ETS)
 category: specifics
-order: 3
+order: 4
 lang: es
 ---
 

--- a/vi/lessons/specifics/eex.md
+++ b/vi/lessons/specifics/eex.md
@@ -2,7 +2,7 @@
 layout: page
 title: Embedded Elixir (EEx)
 category: specifics
-order: 4
+order: 3
 lang: vi
 ---
 

--- a/vi/lessons/specifics/ets.md
+++ b/vi/lessons/specifics/ets.md
@@ -2,7 +2,7 @@
 layout: page
 title: Erlang Term Storage (ETS)
 category: specifics
-order: 3
+order: 4
 lang: vi
 ---
 


### PR DESCRIPTION
There were only two languages that needed updated (en & vi) regarding the specifics lessons. The other languages are yet to add any content to this section.

