### PR TITLE
Changed sidebar language links to be relative.

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -38,7 +38,7 @@
       {% endif %}
 
       {% for lang in site.languages %}
-        <a href="{% if lang == site.default_lang %} {{site.url}}{{url}} {% else %} {{site.url}}/{{lang}}{{url}} {% endif %}">{{lang}}</a>
+        <a href="{% if lang == site.default_lang %} {{url}} {% else %} /{{lang}}{{url}} {% endif %}">{{lang}}</a>
       {% endfor %}
     </p>
 


### PR DESCRIPTION
Right now there is a very confusing behaviour when running the project locally - when you change language via link in the sidebar, you are redirected to the https://elixirschool.com instead of your local version of the site.

This PR should not change anything in production, but will simplify usability for translators a bit.
