### PR TITLE
Mix lesson changes

### DIFF
--- a/lessons/basics/mix.md
+++ b/lessons/basics/mix.md
@@ -70,6 +70,16 @@ The first section we'll look at is `project`.  Here we define the name of our ap
 
 The `application` section is used during the generation of our application file which we'll cover next.
 
+## Interactive
+
+It may be necessary to use `iex` within the context of our application.  Thankfully for us, mix makes this easy.  We can start a new `iex` session:
+
+```bash
+$ iex -S mix
+```
+
+Starting `iex` this way will load your application and dependencies into the current runtime.
+
 ## Compilation
 
 Mix is smart and will compile your changes when necessary, but it may still be necessary explicitly compile your project.  In this section we'll cover how to compile our project and what compilation does.
@@ -88,16 +98,6 @@ Generated example app
 ```
 
 When we compile a project mix creates a `_build` directory for our artifacts.  If we look inside `_build` we will see our compiled application: `example.app`.
-
-## Interactive
-
-It may be necessary to use `iex` within the context of our application.  Thankfully for us, mix makes this easy.  With our application compiled we can start a new `iex` session:
-
-```bash
-$ iex -S mix
-```
-
-Starting `iex` this way will load your application and dependencies into the current runtime.
 
 ## Manage Dependencies
 


### PR DESCRIPTION
Moved 'interaction' section before the 'compilation'.
Removed reference to project compilation requirement to use iex.

Current wording is a bit confusing. ( _With our application compiled we can start a new `iex` session:		_ ) From this one might tell that this is caused by the fact app is compiled, while really it's working without compilation too.

Also, I've moved the 'iex' part before the compilation, because it's very widely used.