### PR TITLE
Updating/Fixing grammatical errors

### DIFF
--- a/es/lessons/basics/basics.md
+++ b/es/lessons/basics/basics.md
@@ -150,7 +150,7 @@ iex> 10 / 5
 2.0
 ```
 
-Si tu necesitas una división entera o el resto de una división, Elixir viene con dos funciones útiles para para lograr esto:
+Si tú necesitas una división entera o el resto de una división, Elixir viene con dos funciones útiles para para lograr esto:
 
 ```elixir
 iex> div(10, 5)
@@ -197,7 +197,7 @@ iex> not 42
 
 ### Comparación
 
-Elixir viene con todos los operadores de comparación a los que estamos acostumbrados: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` and `>`.
+Elixir viene con todos los operadores de comparación a los que estamos acostumbrados: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` y `>`.
 
 ```elixir
 iex> 1 > 2
@@ -219,7 +219,7 @@ iex> 2 === 2.0
 false
 ```
 
-Una característica importante de Elixir es que cualquier par de tipos se pueden comparar, esto es útil particularmente en ordenación. No necesitamos memorizar el orden pero es importante ser consiente de este:
+Una característica importante de Elixir es que cualquier par de tipos se pueden comparar, esto es útil particularmente en ordenación. No necesitamos memorizar el orden pero es importante ser consciente de este:
 
 ```elixir
 number < atom < reference < functions < port < pid < tuple < maps < list < bitstring
@@ -236,7 +236,7 @@ false
 
 ### Interpolación de cadenas
 
-Si haz usado Ruby, la interpolación de cadenas en Elixir te parecerá muy familiar:
+Si has usado Ruby, la interpolación de cadenas en Elixir te parecerá muy familiar:
 
 ```elixir
 iex> name = "Sean"

--- a/es/lessons/basics/collections.md
+++ b/es/lessons/basics/collections.md
@@ -21,14 +21,14 @@ Listas, tuplas, listas de palabras clave, mapas, diccionarios y combinadores fun
 
 ## Listas
 
-Las listas son simples colecciones de valores, estas pueden incluir múltiples tipos; las listas puede incluir valores no únicos
+Las listas son simples colecciones de valores. Estas pueden incluir múltiples tipos; las listas pueden incluir valores no únicos:
 
 ```elixir
 iex> [3.41, :pie, "Apple"]
 [3.41, :pie, "Apple"]
 ```
 
-Elixir implementa las listas como listas enlazadas. Esto significa que acceder a la longitud de la lista es una operación `O(n)`. Por esta razón, normalmente es más rápido agregar un elemento al inicio que al final.
+Elixir implementa las listas como listas enlazadas. Esto significa que acceder a la longitud de la lista es una operación `O(n)`. Por esta razón, normalmente es más rápido agregar un elemento al inicio que al final:
 
 ```elixir
 iex> list = [3.41, :pie, "Apple"]
@@ -42,7 +42,7 @@ iex> list ++ ["Cherry"]
 
 ### Concatenación de listas
 
-La concatenación de listas usa el operador `++/2`.
+La concatenación de listas usa el operador `++/2`:
 
 ```elixir
 iex> [1, 2] ++ [3, 4, 1]
@@ -119,7 +119,7 @@ Por estas razones las listas de palabras clave son comúnmente usadas para pasar
 
 ## Mapas
 
-A diferencia de las listas de palabras clave estos permiten llaves de cualquier tipo y no siguen un órden. Tu puedes definir un mapa con la sintaxis `%{}`:
+A diferencia de las listas de palabras clave estos permiten llaves de cualquier tipo y no siguen un orden. Tú puedes definir un mapa con la sintaxis `%{}`:
 
 ```elixir
 iex> map = %{:foo => "bar", "hello" => :world}
@@ -149,7 +149,7 @@ true
 
 ## Diccionarios
 
-En Elixir, ambos, listas de palabras claves y mapas implementan el módulo `Dict`; como tales se conocen colectivamente como diccionarios. Si necesitas construir tu propio almacenamiento clave-valor, implementar el módulo `Dict` es un buen lugar para empezar.
+En Elixir, ambos, listas de palabras claves y mapas implementan el módulo `Dict`; tales se conocen colectivamente como diccionarios. Si necesitas construir tu propio almacenamiento clave-valor, implementar el módulo `Dict` es un buen lugar para empezar.
 
 El [módulo `Dict`](http://elixir-lang.org/docs/stable/elixir/#!Dict.html) provee un número de funciones útiles para interactuar y manipular esos diccionarios:
 

--- a/es/lessons/basics/composition.md
+++ b/es/lessons/basics/composition.md
@@ -21,7 +21,7 @@ Sabemos por experiencia que es revoltoso tener nuestras funciones en el mismo ar
 
 ## Modulos
 
-Los módulos son la mejor manera de organizar funciones en un namespace. En adición a las funciones agrupativas, los módulos nos permiten definir funciones nombradas y privadas, las cuales cubrimos en la lección pasada
+Los módulos son la mejor manera de organizar funciones en un namespace. En adición a las funciones agrupativas, los módulos nos permiten definir funciones nombradas y privadas, las cuales cubrimos en la lección pasada.
 
 Démosle un vistazo a un ejemplo básico:
 
@@ -36,7 +36,7 @@ iex> Example.greeting "Sean"
 "Hello Sean."
 ```
 
-Es posible anidar módulos en Elixir, permitiendonos ser explícitos nombrando nuestra funcionalidad.
+Es posible anidar módulos en Elixir, permitiéndonos ser explícitos nombrando nuestra funcionalidad.
 
 
 ```elixir
@@ -133,7 +133,7 @@ end
 
 defmodule Example do
   alias Sayings.Greetings
-  
+
   def greeting(name), do: Greetings.basic(name)
 end
 
@@ -149,12 +149,12 @@ Si hay un conflicto entre dos alias o quieres que los alias tomen un nombre dife
 ```elixir
 defmodule Example do
   alias Sayings.Greetings, as: Hi
-  
+
   def print_message(name), do: Hi.basic(name)
 end
 ```
 
-Es posible dar multiples alias a un módulo a la vez:
+Es posible dar múltiples alias a un módulo a la vez:
 
 ```elixir
 defmodule Example do
@@ -164,7 +164,7 @@ end
 
 ### `import`
 
-Si queremos importar las funciones y macros de un módulo, más que sólo darle un alias, podemos utilizar `import/` 
+Si queremos importar las funciones y macros de un módulo, más que sólo darle un alias, podemos utilizar `import/`:
 
 ```elixir
 iex> last([1, 2, 3])
@@ -199,7 +199,7 @@ iex> last([1, 2, 3])
 ** (CompileError) iex:3: undefined function last/1
 ```
 
-En adición a los pares nombre/aridad, hay dos atomos especiales, `:functions` y `:macros`, las cuales importan únicamente funciones y macros, respectivamente:
+En adición a los pares nombre/aridad, hay dos átomos especiales, `:functions` y `:macros`, las cuales importan únicamente funciones y macros, respectivamente:
 
 ```elixir
 import List, only: :functions
@@ -223,7 +223,7 @@ Si intentamos hacer un llamado a una macro que no está cargada aún, Elixir arr
 ### `use`
 
 Utiliza el módulo en el contexto actual. Esto es particularmente utilizado cuando un módulo necesita realizar algún setup. Llamando `use`, invocamos el hook `__using__` dentro del módulo, dándole al módulo una oportunidad para modificar nuestro contexto actual.
- 
+
 ```elixir
 defmodule MyModule do
   defmacro __using__(opts) do

--- a/es/lessons/basics/control-structures.md
+++ b/es/lessons/basics/control-structures.md
@@ -16,7 +16,7 @@ En esta lección veremos las estructuras de control disponibles en Elixir
 
 ## `if` y `unless`
 
-Es probable que haya visto `if/2` antes, y si ha utilizado Ruby esta familiarizado con `unless/2`. En Elixir ellos funcionan de la misma forma pero estan definidos como macros, no son construcciones propias del lenguaje; puede encontrar su implementación en el [módulo Kernel](http://elixir-lang.org/docs/stable/elixir/#!Kernel.html).
+Es probable que hayas visto `if/2` antes, y si has utilizado Ruby, estás familiarizado con `unless/2`. En Elixir ellos funcionan de la misma forma pero están definidos como macros, no son construcciones propias del lenguaje; puedes encontrar su implementación en el [módulo Kernel](http://elixir-lang.org/docs/stable/elixir/#!Kernel.html).
 
 
 Debería tomarse en cuenta que en Elixir, los únicos valores falsos son `nil` y el booleano `false`.
@@ -72,7 +72,7 @@ iex> case :even do
 "Not Odd"
 ```
 
-Considera `_` como el `else` the coincidirá con "todo lo demás".
+Considera `_` como el `else` que coincidirá con "todo lo demás".
 Ya que `case` se basa en la coincidencia de patrones, las mismas reglas y restricciones se aplican. Si intentas coincidir con variables existentes debes usar el operador pin `^`:
 
 ```elixir
@@ -120,7 +120,7 @@ iex> cond do
 "But this will"
 ```
 
-Como `case`, `cond` alzará un error si no hay una coincidencia. Para manejar esto, podemos definir una condición cuyo valor es `true`:
+Como `case`, `cond` alzará un error si no hay una coincidencia, para manejar esto, podemos definir una condición cuyo valor es `true`:
 
 ```elixir
 iex> cond do

--- a/es/lessons/basics/enum.md
+++ b/es/lessons/basics/enum.md
@@ -25,14 +25,14 @@ Un conjunto de algoritmos para hacer enumeración sobre colecciones.
 
 ## Enum
 
-El módulo `Enum` incluye mas de cien funciones para trabajar con las colleciones que aprendimos en la última lección.
+El módulo `Enum` incluye más de cien funciones para trabajar con las colecciones que aprendimos en la última lección.
 
-Esta lección solo cubrirá un subconjunto de las funciones disponibles, para ver la lista completa de funciones visita la documentación oficial [`Enum`](http://elixir-lang.org/docs/v1.0/elixir/Enum.html); para enumeración perezosa usa el módulo [`Stream`](http://elixir-lang.org/docs/v1.0/elixir/Stream.html).
+Esta lección solo cubrirá un subconjunto de las funciones disponibles. Para ver la lista completa de funciones visita la documentación oficial [`Enum`](http://elixir-lang.org/docs/v1.0/elixir/Enum.html); para enumeración perezosa usa el módulo [`Stream`](http://elixir-lang.org/docs/v1.0/elixir/Stream.html).
 
 
 ### all?
 
-Cuando usas `all?`, y muchas de la funciones de `Enum`, proveemos una función para aplicar a los elementos de nuestra colección. En el caso de `all?`, la colección entera debe ser evaluada a `true`, en otro caso `false` será retornado:
+Cuando usas `all?`, y muchas de las funciones de `Enum`, proveemos una función para aplicar a los elementos de nuestra colección. En el caso de `all?`, la colección entera debe ser evaluada a `true`, en otro caso `false` será retornado:
 
 ```elixir
 iex> Enum.all?(["foo", "bar", "hello"], fn(s) -> String.length(s) == 3 end)
@@ -52,14 +52,14 @@ true
 
 ### chunk
 
-Si necesitas romper tu colleción en pequeños grupos, `chunk` es la función que probablemente estás buscando:
+Si necesitas romper tu colección en pequeños grupos, `chunk` es la función que probablemente estás buscando:
 
 ```elixir
 iex> Enum.chunk([1, 2, 3, 4, 5, 6], 2)
 [[1, 2], [3, 4], [5, 6]]
 ```
 
-Hay algunas opciones para `chunk` pero no vamos a entrar en ellas, revisa [`chunk/2`](http://elixir-lang.org/docs/v1.0/elixir/Enum.html#chunk/2) en la documentación oficial para aprender mas.
+Hay algunas opciones para `chunk` pero no vamos a entrar en ellas, revisa [`chunk/2`](http://elixir-lang.org/docs/v1.0/elixir/Enum.html#chunk/2) en la documentación oficial para aprender más.
 
 ### chunk_by
 
@@ -123,7 +123,7 @@ iex> Enum.reduce([1, 2, 3], fn(x, acc) -> x + acc end)
 
 ### sort
 
-Ordenar nuestras colecciones se hace fácil con no una sino dos funciones de ordenación. La primera opción disponible para nosotros utiliza el criterio de Elixir para determinar el orden de ordenación:
+Ordenar nuestras colecciones se hace fácil con no una, sino dos funciones de ordenación. La primera opción disponible para nosotros utiliza el criterio de Elixir para determinar el orden de ordenación:
 
 ```elixir
 iex> Enum.sort([5, 6, 1, 3, -1, 4])

--- a/es/lessons/basics/functions.md
+++ b/es/lessons/basics/functions.md
@@ -6,7 +6,7 @@ order: 6
 lang: es
 ---
 
-En Elixir y en muchos lenguajes funcionales, las funciones son ciudadanos de primera clase. Vamos a aprender acerca de los tipos de funciones en Elixir, que los hace diferentes, y como usarlos.
+En Elixir y en muchos lenguajes funcionales, las funciones son ciudadanos de primera clase. Vamos a aprender acerca de los tipos de funciones en Elixir, qué los hace diferentes, y cómo usarlos.
 
 ## Tabla de Contenidos
 
@@ -20,7 +20,7 @@ En Elixir y en muchos lenguajes funcionales, las funciones son ciudadanos de pri
 
 ## Funciones anónimas
 
-Tal como el nombre sugiere, una función anónima no tiene nombre. Como vimos en la lección `Enum`, ellas son pasadas frecuentemente a otra funciones. Para definir una función anónima en Elixir necesitamos las palabras clave `fn` y `end`. Dentro de estos podemos definir, separados por `->`, cualquier número de parámetros y el cuerpo de la función.
+Tal como el nombre sugiere, una función anónima no tiene nombre. Como vimos en la lección `Enum`, ellas son pasadas frecuentemente a otras funciones. Para definir una función anónima en Elixir necesitamos las palabras clave `fn` y `end`. Dentro de estos podemos definir, separados por `->`, cualquier número de parámetros y el cuerpo de la función.
 
 Vamos a ver un ejemplo básico:
 
@@ -40,11 +40,11 @@ iex> sum.(2, 3)
 5
 ```
 
-Como probablemente ya haz adivinado, en la versión reducida nuestros parámetros están disponible como `&1`, `&2`, `&3`.
+Como probablemente ya has adivinado, en la versión reducida nuestros parámetros están disponible como: `&1`, `&2`, `&3`.
 
 ## Coincidencia de patrones
 
-La coincidencia de patrones no esta limitada solo a las variables en Elixir, puede ser aplicada a las firmas de la función como veremos en esta sección.
+La coincidencia de patrones no está limitada solo a las variables en Elixir, puede ser aplicada a las firmas de la función como veremos en esta sección.
 
 Elixir usa coincidencia de patrones para identificar el primer conjunto de parámetros que coincidan e invocar al cuerpo correspondiente:
 
@@ -64,9 +64,9 @@ An error has occurred!
 
 ## Funciones con nombre
 
-Podemos definir funciones con nombre para asi poder referirnos a ellas luego, estas funciones con nombre son definidas con la palabra clave `def` dentro de un módulo, Vamos a aprender mas acerca de los módulos en las siguientes lecciones, por ahora nos enfocaremos solamente en las funciones con nombre.
+Podemos definir funciones con nombre para así poder referirnos a ellas luego. Estas funciones con nombre son definidas con la palabra clave `def` dentro de un módulo. Vamos a aprender más acerca de los módulos en las siguientes lecciones, por ahora nos enfocaremos solamente en las funciones con nombre.
 
-Las funciones definidas dentro de un módulo estan disponibles para ser usadas por otros módulos, esto es particularmente útil para construir bloques en Elixir:
+Las funciones definidas dentro de un módulo están disponibles para ser usadas por otros módulos, esto es particularmente útil para construir bloques en Elixir:
 
 ```elixir
 defmodule Greeter do
@@ -79,7 +79,7 @@ iex> Greeter.hello("Sean")
 "Hello, Sean"
 ```
 
-Si el cuerpo de nuestra función solo se extiende a una linea, podemos acortarla con `do:`:
+Si el cuerpo de nuestra función solo se extiende a una línea, podemos acortarla con `do:`:
 
 ```elixir
 defmodule Greeter do
@@ -121,9 +121,9 @@ iex> Greeter.phrase
 
 ### Guardas
 
-Hemos cubierto brevemente las guardas en la lección [Estructuras de control](../control-structures.md), ahora veremos como aplicarlas a las funciones con nombre. Una vez Elixir ha coincidido una función algunas guardas serán evaluadas.
+Hemos cubierto brevemente las guardas en la lección [Estructuras de control](../control-structures.md), ahora veremos cómo aplicarlas a las funciones con nombre. Una vez Elixir ha coincidido una función algunas guardas serán evaluadas.
 
-En el siguiente ejemplo tenemos dos funciones con la misma firma, confiamos en las guardas para determinar cual usar basandonos en el tipo de los argumentos:
+En el siguiente ejemplo tenemos dos funciones con la misma firma, confiamos en las guardas para determinar cuál usar basándonos en el tipo de los argumentos:
 
 ```elixir
 defmodule Greeter do

--- a/es/lessons/basics/mix.md
+++ b/es/lessons/basics/mix.md
@@ -6,7 +6,7 @@ order: 8
 lang: es
 ---
 
-Antes que podamos sumergirnos en las profundas aguas de Elixir primero necesitamos aprender acerca de mix. Si estas familiarizado con Ruby mix es Bundler, RubyGems, y Rake combinados. Es una parte crucial de cualquier proyecto Elixir y en esta lección vamos a explorar solo algunas de sus grandiosas características. Para ver todo lo que mix ofrece ejecutamos `mix help`.
+Antes que podamos sumergirnos en las profundas aguas de Elixir primero necesitamos aprender acerca de mix. Si estás familiarizado con Ruby, mix es Bundler, RubyGems y Rake combinados. Es una parte crucial de cualquier proyecto Elixir y en esta lección vamos a explorar solo algunas de sus grandiosas características. Para ver todo lo que mix ofrece ejecutamos `mix help`.
 
 Hasta ahora hemos estado trabajando exclusivamente dentro de `iex` con sus limitaciones. Para construir algo sustancial necesitamos dividir nuestro código en varios archivos efectivamente y administrarlos, mix nos permite hacer eso con proyectos.
 
@@ -41,7 +41,7 @@ De la salida podemos ver que mix ha creado nuestro directorio y un número de ar
 * creating test/example_test.exs
 ```
 
-En esta sección vamos a enfocar nuestra atención en `mix.exs`. Aqui configuramos nuestra aplicación, dependencias, entornos, y versión. Abra el archivo en su editor favorito, debería ver algo como esto (comentarios eliminados por brevedad):
+En esta sección vamos a enfocar nuestra atención en `mix.exs`. Aquí configuramos nuestra aplicación, dependencias, entornos, y versión. Abre el archivo en tu editor favorito, deberías ver algo como esto (comentarios eliminados por brevedad):
 
 ```elixir
 defmodule Example.Mixfile do
@@ -66,13 +66,13 @@ defmodule Example.Mixfile do
 end
 ```
 
-La primera sección que vamos a ver es `project`. Aqui vamos a definir el nombre de nuestra aplicación(`app`), especificar la versión(`version`), la versión de Elixir(`elixir`), y finalmente nuestras dependencias(`deps`).
+La primera sección que vamos a ver es `project`. Aquí vamos a definir el nombre de nuestra aplicación(`app`), especificar la versión(`version`), la versión de Elixir(`elixir`), y finalmente nuestras dependencias(`deps`).
 
 La sección `application` es usada durante la generación de nuestro archivo de aplicación el cual cubriremos a continuación.
 
 ## Compilación
 
-Mix es inteligente y compilará tus cambios cuando sea necesario, pero todavia puede ser necesario compilar su proyecto explicitamente. En esta sección vamos a cubrir como compilar nuestro proyecto y como se hace la compilación.
+Mix es inteligente y compilará tus cambios cuando sea necesario, pero todavia puede ser necesario compilar tu proyecto explícitamente. En esta sección vamos a cubrir cómo compilar nuestro proyecto y como se hace la compilación.
 
 Para compilar un proyecto mix solo necesitamos ejecutar `mix compile` en nuestro directorio base:
 
@@ -80,7 +80,7 @@ Para compilar un proyecto mix solo necesitamos ejecutar `mix compile` en nuestro
 $ mix compile
 ```
 
-No hay mucho en nuestro proyecto por eso la salida no es tan emocionante pero esto debería completarse satisfactoriamente:
+No hay mucho en nuestro proyecto, por eso la salida no es tan emocionante así que esto debería completarse satisfactoriamente:
 
 ```bash
 Compiled lib/example.ex
@@ -91,7 +91,7 @@ Cuando compilamos un proyecto mix crea un directorio `_build` para nuestros arte
 
 ## Interactivo
 
-Puede ser necesario usar `iex` dentro del contexto de nuestra aplicación. Por suerte para nosotros, mix hace esto facil. Con nuestra aplicación compilada podemos empezar una nueva sesión `iex`:
+Puede ser necesario usar `iex` dentro del contexto de nuestra aplicación. Por suerte para nosotros, mix hace esto fácil. Con nuestra aplicación compilada podemos empezar una nueva sesión `iex`:
 
 ```bash
 $ iex -S mix
@@ -101,9 +101,9 @@ Empezando `iex` de esta forma mix cargará nuestra aplicación y dependencias en
 
 ## Administrar dependencias
 
-Nuestro proyecto no tiene ninguna dependencia pero lo hará en breve, vamos a seguir adelante para definir las dependencias y obtenerlas.
+Nuestro proyecto no tiene ninguna dependencia pero lo hará en breve. Vamos a seguir adelante para definir las dependencias y obtenerlas.
 
-Para agregar una nueva dependencia primero necesitamos agregarla a nuestro archivo `mix.exs` en la sección `deps`. Nuestra lista de dependencias esta compuesta de tuplas con dos valores requeridos y uno opcional: El nombre del paquete como un átomo, la versión como una cadena, y opciones opcionales.
+Para agregar una nueva dependencia primero necesitamos agregarla a nuestro archivo `mix.exs` en la sección `deps`. Nuestra lista de dependencias está compuesta de tuplas con dos valores requeridos y uno opcional: El nombre del paquete como un átomo, la versión como una cadena, y opciones (opcionales).
 
 Para este ejemplo vamos a ver un proyecto con dependencias, como [phoenix_slim](https://github.com/doomspork/phoenix_slim):
 
@@ -116,9 +116,9 @@ def deps do
 end
 ```
 
-Como probablemente ha visto en las dependencias arriba, la dependencia `cowboy` es la única necesaria durante desarrollo y pruebas.
+Como probablemente has visto en las dependencias arriba, la dependencia `cowboy` es la única necesaria durante desarrollo y pruebas.
 
-Una vez que hemos definido nuestras dependencias hay un paso final, obtenerlas. Esto es análogo a `bundle install`:
+Una vez que hemos definido nuestras dependencias hay un paso final: obtenerlas. Esto es análogo a `bundle install` (en Ruby):
 
 ```bash
 $ mix deps.get

--- a/es/lessons/basics/pattern-matching.md
+++ b/es/lessons/basics/pattern-matching.md
@@ -6,7 +6,7 @@ order: 4
 lang: es
 ---
 
-La coincidencia de patrones es una parte poderosa de Elixir, nos permite coincidir valores simples, estructuras de datos, e incluso funciones. En esta lección vamos a comenzar a ver como es usada la coincidencia de patrones.
+La coincidencia de patrones es una parte poderosa de Elixir, nos permite coincidir valores simples, estructuras de datos, e incluso funciones. En esta lección vamos a comenzar a ver cómo es usada la coincidencia de patrones.
 
 ## Tabla de Contenidos
 
@@ -61,7 +61,7 @@ iex> {:ok, value} = {:error}
 
 Como hemos aprendido, el operador de coincidencia maneja la asignación cuando el lado izquierdo de la coincidencia incluye una variable. En algunos casos este comportamiento, re-enlazamiento de variable, no es el deseado. Para esas situaciones, tenemos el operador `^`.
 
-Cuando usamos el operador pin con una variable, hacemos una coincidencia sobre el valor existente en lugar de enlazarlo a uno nuevo. Vamos a ver como funciona esto:
+Cuando usamos el operador pin con una variable, hacemos una coincidencia sobre el valor existente en lugar de enlazarlo a uno nuevo. Vamos a ver cómo funciona esto:
 
 ```elixir
 iex> x = 1

--- a/es/lessons/basics/pipe-operator.md
+++ b/es/lessons/basics/pipe-operator.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: Operador Pipe 
+title: Operador Pipe
 category: basics
-order: 6 
+order: 6
 lang: es
 ---
 
@@ -12,11 +12,11 @@ El operador pipe `|>` pasa el resultado de una expresión como el primer paráme
 
 - [Introducción](#introduction)
 - [Ejemplos](#examples)
-- [Buenas Practicas](#best-practices)
+- [Buenas Prácticas](#best-practices)
 
 ## Introducción
 
-La programación puede ser desordenada. De hecho, los llamados de función que estan contenidos dentro de otra función se vuelven muy difícil de seguir. Por ejemplo, tome las siguientes funciones anidadas en consideración:
+La programación puede ser desordenada. De hecho, los llamados de función que están contenidos dentro de otra función se vuelven muy difíciles de seguir. Por ejemplo, tome las siguientes funciones anidadas en consideración:
 
 
 ```elixir
@@ -33,7 +33,7 @@ El operador lleva el resultado de la izquierda, y lo pasa a la derecha.
 
 ## Ejemplos
 
-Para este grupo de ejemplos, usaremos el modulo String de elixir.
+Para este grupo de ejemplos, usaremos el módulo String de elixir.
 
 - Separar Cadenas (Tokenize String)
 
@@ -56,10 +56,9 @@ iex> "elixir" |> String.ends_with?("ixir")
 true
 ```
 
-## Buenas Practicas
+## Buenas Prácticas
 
-Si la función recibe más de 1 parámetro, asegúrese de usar paréntesis. 
-Honestamente no importa mucho en elixir, pero es importante para otros programadores que pueden malinterpretar nuestro codigo. Si en el segundo ejemplo removemos los paréntesis de `Enum.map/2`, tendríamos la siguiente advertencia.
+Si la función recibe más de 1 parámetro, asegúrese de usar paréntesis. Honestamente no importa mucho en elixir, pero es importante para otros programadores que pueden malinterpretar nuestro código. Si en el segundo ejemplo removemos los paréntesis de `Enum.map/2`, tendríamos la siguiente advertencia.
 
 ```shell
 iex> "Elixir language" |> String.split |> Enum.map &String.upcase/1
@@ -73,4 +72,3 @@ foo(1) |> bar(2) |> baz(3)
 
 ["ELIXIR", "LANGUAGE"]
 ```
-


### PR DESCRIPTION
Updating/fixing grammatical errors at spanish translations (for basic guides).