### PR TITLE
Design feedback

### DIFF
--- a/_assets/stylesheets/custom.scss
+++ b/_assets/stylesheets/custom.scss
@@ -9,6 +9,9 @@
 .theme-custom-purple .related-posts li a:hover {
   color: #4A365F;
 }
+.theme-custom-purple .content a {
+  text-decoration: underline;
+}
 
 h2 {
  color: #F07E6B;

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ description:
   gr: Μαθήματα προγραμματισμού της γλώσσας Elixir
   it: Lezioni sul linguaggio di programmazione Elixir
   my: Pelajaran mengenai bahasa aturcara Elixir
+baseurl: /
 url: https://elixirschool.com
 og_image: https://elixirschool.com/assets/fb_share.jpg
 permalink: pretty


### PR DESCRIPTION
This PR fixes the missing baseurl in the _config.yml file and defaults it to /. While browsing the site, I found it incredibly hard to see links in the content body. I've added an underline to all content body links. 

The only place I've noticed "odd" behavior is when the link contains code block, in which I question whether a code tag should even be in a link.

Issue Reference: #281 