### PR TITLE
[PT-BR] Fix typos and anchors on summaries

### DIFF
--- a/pt/lessons/advanced/error-handling.md
+++ b/pt/lessons/advanced/error-handling.md
@@ -110,7 +110,7 @@ iex> try do
 %ExampleError{message: "an example error has occurred"}
 ```
 
-## Lançar
+## <a name="lancar"></a>Lançar
 
 Outro mecanismo para trabalhar com erros no Elixir é `throw` e `catch`. Na prática, isso não ocorre frequentemente no código mais recente de Elixir. Mas, é importante conhecer e entendê-los mesmo assim.
 

--- a/pt/lessons/advanced/metaprogramming.md
+++ b/pt/lessons/advanced/metaprogramming.md
@@ -143,7 +143,7 @@ end
 
 Embora não seja tão comum, Elixir suporta macros privadas. Um macro privado é definido com `defmacro` e só pode ser chamado a partir do módulo no qual ele foi definido. Macros privados devem ser definidas antes do código que as invoca.
 
-### <a name="higienizacao-de-macro">Higienização de Macro
+### <a name="higienizacao-de-macros">Higienização de Macros
 
 A característica de como macros interagem com o contexto de quem o chamou quando expandido é conhecida como a higienização de macro. Por padrão macros no Elixir são higiênicos e não entrarão em conflito com nosso contexto:
 

--- a/pt/lessons/advanced/otp-supervisors.md
+++ b/pt/lessons/advanced/otp-supervisors.md
@@ -17,7 +17,7 @@ Supervisores são processos especializados com um propósito: monitorar outros p
   - [Instalação](#instalacao)
   - [Tarefas Supervisionadas](#tarefas-supervisionadas)
 
-##<a name="configuracao"></a> Configuração
+## <a name="configuracao"></a>Configuração
 
 A magia de Supervisores está na função `Supervisor.start_link/2`. Além de iniciar nosso supervisor e filhos, nos permite definir a estratégia que nosso supervisor irá usar para gerenciar os processos filhos.
 
@@ -37,7 +37,7 @@ children = [
 
 Se o nosso processo fosse falhar ou ser encerrado, nosso Supervisor iria automaticamente reiniciar este processo como se nada tivesse acontecido.
 
-###<a name="estrategias"></a> Estratégias
+### <a name="estrategias"></a>Estratégias
 
 Atualmente, existem quatro estratégias diferentes de reinicialização disponíveis aos supervisores:
 
@@ -49,7 +49,7 @@ Atualmente, existem quatro estratégias diferentes de reinicialização disponí
 
 + `:simple_one_for_one` - O melhor para processos filhos dinamicamente adicionados. É requerido que o Supervisor tenha apenas um filho.
 
-###<a name="nesting"></a> Nesting
+### Nesting
 
 Além de processos de trabalho também podemos supervisionar surpevisores para criar uma árvore de supervisores. A única diferença para nós é trocar `supervisor/3` por `worker/3`.
 
@@ -68,7 +68,7 @@ children = [
 
 Tarefas têm o seu próprio Supervisor especializado, o `Task.Supervisor`. Projetado para tarefas criadas dinamicamente. O supervisor usa `:simple_one_for_one` por debaixo dos panos.
 
-###<a name="instalacao"></a> Instalação
+### <a name="instalacao"></a>Instalação
 
 Incluir o `Task.Supervisor` não é diferente de outros supervisores:
 

--- a/pt/lessons/basics/basics.md
+++ b/pt/lessons/basics/basics.md
@@ -19,14 +19,14 @@ Instalação, tipos básicos e operações básicas.
 	- [Booleanos](#booleanos)
 	- [Átomos](#atomos)
 	- [Strings](#strings)
-- [Operações Básicas](#operaciones-basicas)
+- [Operações Básicas](#operacoes-basicas)
 	- [Aritmética](#aritmetica)
 	- [Booleanas](#booleanas)
 	- [Comparação](#comparacao)
-	- [Interpolação de String](#interpolacao-de-string)
-	- [Concatenação de String](#concatenacao-de-string)
+	- [Interpolação de Strings](#interpolacao-de-strings)
+	- [Concatenação de Strings](#concatenacao-de-strings)
 
-## Instalação
+## <a name="instalacao"></a>Instalação
 
 ### Instalar Elixir
 
@@ -43,7 +43,7 @@ Para iniciar, executamos `iex`:
 	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
-## Tipos Básicos
+## <a name="tipos"></a>Tipos Básicos
 
 ### Inteiros
 
@@ -133,9 +133,9 @@ iex(10)> "foo\nbar"
 "foo\nbar"
 ```
 
-## Operações Básicas
+## <a name="operacoes-basicas"></a>Operações Básicas
 
-### Aritmética
+### <a name="aritmetica"></a>Aritmética
 
 Elixir suporta os operadores básicos `+`, `-`, `*`, e `/` como era de esperar. É importante ressaltar que `/` sempre retornará um número ponto flutuante:
 
@@ -195,7 +195,7 @@ iex> not 42
 ** (ArgumentError) argument error
 ```
 
-### Comparação
+### <a name="comparacao"></a>Comparação
 
 Elixir vem com todos os operadores de comparação que estamos acostumados a usar: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` e `>`.
 
@@ -234,7 +234,7 @@ iex> {:hello, :world} > [1, 2, 3]
 false
 ```
 
-### Interpolação de Strings
+### <a name="interpolacao-de-strings"></a>Interpolação de Strings
 
 Se você já usou Ruby, a interpolação de strings em Elixir parecerá muito familiar:
 
@@ -244,7 +244,7 @@ iex> "Hello #{name}"
 "Hello Sean"
 ```
 
-### Concatenação de Strings
+### <a name="concatenacao-de-strings"></a>Concatenação de Strings
 
 A concatenação de strings usa o operador `<>`:
 

--- a/pt/lessons/basics/collections.md
+++ b/pt/lessons/basics/collections.md
@@ -39,7 +39,7 @@ iex> list ++ ["Cherry"]
 ```
 
 
-### Concatenação de listas
+### <a name="concatenacao-de-listas"></a>Concatenação de listas
 
 A concatenação de listas usa o operador `++/2`.
 
@@ -48,7 +48,7 @@ iex> [1, 2] ++ [3, 4, 1]
 [1, 2, 3, 4, 1]
 ```
 
-### Subtração de listas
+### <a name="subtracao-de-listas"></a>Subtração de listas
 
 O suporte para subtração é provido pelo operador `--/2`; é seguro subtrair um valor que não existe:
 

--- a/pt/lessons/basics/composition.md
+++ b/pt/lessons/basics/composition.md
@@ -53,7 +53,7 @@ iex> Example.Greetings.morning "Sean"
 "Good morning Sean."
 ```
 
-### Atributos de módulo
+### <a name="atributos-de-modulo"></a>Atributos de módulo
 
 Atributos de módulo são mais comumente usados como constantes no Elixir. Vamos dar uma olhada em um exemplo simples:
 
@@ -114,7 +114,7 @@ iex> %{name: "Sean"} = sean
 %Example.User{name: "Sean", roles: [:admin, :owner]}
 ```
 
-## Composição
+## <a name="composicao"></a>Composição
 
 Agora que sabemos como criar módulos e structs, vamos aprender a incluir uma funcionalidade existente neles através da composição. Elixir nos fornece uma variedade de maneiras diferentes para interagir com outros módulos, vamos ver o que temos à nossa disposição.
 

--- a/pt/lessons/basics/documentation.md
+++ b/pt/lessons/basics/documentation.md
@@ -20,7 +20,7 @@ Documentando código em Elixir.
 - [Boas Práticas](#boas-praticas)
 
 
-## Anotações
+## <a name="anotacoes"></a>Anotações
 
 Quanto nós comentamos e o que faz uma documentação de qualidade continua a ser uma questão controversa dentro do mundo da programação. No entanto, nós podemos concordar que documentação é importante para nós e para aqueles que trabalham com a nossa base de código.
 
@@ -30,7 +30,7 @@ Elixir trata de documentação como uma *cidadã de primeira classe*, oferecendo
   - `@moduledoc` - Para documentação em nível de módulo.
   - `@doc` - Para documentação em nível de função.
 
-### Documentação em Linha
+### <a name="documentacao-em-linha"></a>Documentação em Linha
 
 Provavelmente, a maneira mais simples de comentar o seu código é com comentários em linha. Semelhante a Ruby ou Python, comentário em linha do Elixir é determinado com um `#`, muitas vezes conhecido como um `sustenido`, ou um *hash* dependendo de onde você vive no mundo.
 
@@ -43,7 +43,7 @@ IO.puts "Hello, " <> "chum."
 
 Elixir, ao executar este script irá ignorar tudo, de '#' até o fim da linha, tratando-a como dados ocultos e sem lógica de execução. Pode adicionar nenhum valor para a operação ou o desempenho do script, no entanto, quando não é tão óbvio sobre o que está acontecendo, um programador deve saber ao ler o seu comentário. Esteja atento para não abusar do comentário de uma linha! Bagunçando uma base de código pode se tornar um pesadelo indesejável para alguns. É melhor usar com moderação.
 
-### Documentando Módulos
+### <a name="documentacao-de-modulos"></a>Documentação de  Módulos
 
 A anotação `@moduledoc`  permite a documentação em linha em um nível de módulo. É tipicamente situada logo abaixo da declaração `defmodule` no topo de um arquivo. O exemplo abaixo mostra um comentário de uma linha dentro do `@moduledoc` decorator.
 
@@ -72,7 +72,7 @@ iex> h Greeter
 Provides a function hello/1 to greet a human
 ```
 
-### Documentando Funções
+### <a name="documentacao-de-funcoes"></a>Documentação de Funções
 
 Assim como Elixir nos dá a capacidade para anotação em nível de módulo, ele também permite anotações semelhantes para documentar funções. A anotação `@doc` permite a documentação de funções. A anotação `@doc` fica logo acima da função que está anotando.
 
@@ -201,7 +201,7 @@ Nós especificamos o `only :dev` par de chave-valor, já que não desejamos faze
 
 É interessante notar neste momento, que você não é obrigado a usar Earmark. Você pode mudar a ferramenta de marcação para outras como Pandoc, Hoedown ou Cmark; porém você terá que fazer um pouco mais de configuração, no qual você pode ler sobre [aqui](https://github.com/elixir-lang/ex_doc#changing-the-markdown-tool). Para este tutorial, vamos continuar utilizando Earmark.
 
-### Gerando Documentação
+### <a name="gerando-documentacao"></a>Gerando Documentação
 
 Prosseguindo, a partir da linha de comando execute os dois comandos a seguir:
 
@@ -223,7 +223,7 @@ Podemos ver que Earmark converteu nosso markdown e ExDoc agora é exibido em um 
 
 Agora nós podemos implantar isso para GitHub, o nosso próprio site, mais comumente no [HexDocs][HexDocs](https://hexdocs.pm/).
 
-## Boas Práticas
+## <a name="boas-praticas"></a>Boas Práticas
 
 Adicionar documentação deve ser seguido com as boas práticas orientadas pela linguagem. Desde que Elixir é uma linguagem bastante jovem, muitas normas ainda estão a ser descobertas ao longo do crescimento do ecossistema. A comunidade, entretanto, tem feito esforços para estabelecer as melhores práticas. Para ler mais sobre as melhores práticas veja [O Guia de Estilo Elixir] (https://github.com/niftyn8/elixir_style_guide).
 

--- a/pt/lessons/basics/enum.md
+++ b/pt/lessons/basics/enum.md
@@ -60,7 +60,7 @@ iex> Enum.chunk([1, 2, 3, 4, 5, 6], 2)
 
 Há algumas opções para `chunk` porém não vamos entrar nelas, revise [`chunk/2`](http://elixir-lang.org/docs/v1.0/elixir/Enum.html#chunk/2) na documentação oficial para aprender mais.
 
-### chunk_by
+### <a name="chunk_by"></a>chunk_by
 
 Se necessita agrupar uma coleção baseado em algo diferente do tamanho, podemos usar a função `chunk_by`:
 

--- a/pt/lessons/basics/functions.md
+++ b/pt/lessons/basics/functions.md
@@ -13,13 +13,13 @@ Em Elixir e em várias linguagens funcionais, funções são cidadãos de primei
 - [Funções anônimas](#funcoes-anonimas)
   - [A & taquigrafia](#a--taquigrafia)
 - [Pattern matching](#pattern-matching)
-- [Funçnoes nomeadas](#funcoes-nomeadas)
+- [Funções nomeadas](#funcoes-nomeadas)
   - [Funções privadas](#funcoes-privadas)
   - [Guards](#guards)
   - [Argumentos padrões](#argumentos-padroes)
 
 
-## Funções anônimas
+## <a name="funcoes-anonimas"></a>Funções anônimas
 
 Tal como o nome indica, uma função anônima não tem nome. Como vimos na lição `Enum`, elas são frequentemente passadas para outras funções. Para definir uma função anônima em Elixir nós precisamos das palavras-chave `fn` e `end`. Dentro destes, podemos definir qualquer número de parâmetros e corpos separados por `->`.
 
@@ -63,7 +63,7 @@ iex> handle_result.({:error})
 An error has occurred!
 ```
 
-## Funções nomeadas
+## <a name="funcoes-nomeadas"></a>Funções nomeadas
 
 Nós podemos definir funções com nomes para referir a elas no futuro, estas funções nomeadas são definidas com a palavra-chave `def` dentro de um modulo. Nós iremos aprender mais sobre Modulos nas próximas lições, por agora nós iremos focar apenas nas funções nomeadas.
 
@@ -101,7 +101,7 @@ iex> Length.of [1, 2, 3]
 3
 ```
 
-### Funções privadas
+### <a name="funcoes-privadas"></a>Funções privadas
 
 Quando não quisermos que outros módulos acessem uma função, nós podemos usar funções privadas, que só podem ser chamadas dentro de seus módulos. Nós podemos definir elas em Elixir com `defp`:
 
@@ -144,7 +144,7 @@ iex> Greeter.hello ["Sean", "Steve"]
 "Hello, Sean, Steve"
 ```
 
-### Argumentos padrões
+### <a name="argumentos-padroes"></a>Argumentos padrões
 
 Se nós quisermos um valor padrão para um argumento, nós usamos a sintaxe `argumento \\ valor`:
 

--- a/pt/lessons/basics/mix.md
+++ b/pt/lessons/basics/mix.md
@@ -70,7 +70,7 @@ A primeira seção que iremos analisar é `project`. Aqui nós definimos o nome 
 
 A seção `application` é usada durante a geração do nosso arquivo de aplicação que iremos ver em breve.
 
-## Compilação
+## <a name="compilacao"></a>Compilação
 
 Mix é inteligente e irá compilar as alterações quando necessário, mas ainda pode ser necessário explicitamente compilar o seu projeto. Nesta seção, vamos cobrir a forma de compilar o nosso projeto e o que essa compilação faz.
 
@@ -98,7 +98,7 @@ $ iex -S mix
 
 Iniciando `iex` desta forma , carrega sua aplicação e dependências no atual ambiente de execução.
 
-## Gestão de dependências
+## <a name="gestao-de-dependencias"></a>Gestão de dependências
 
 Nosso projeto não tem nenhuma dependência, mas em breve irá ter, por isso iremos seguir em frente e cobrir a definição e busca de dependências.
 

--- a/pt/lessons/basics/sigils.md
+++ b/pt/lessons/basics/sigils.md
@@ -57,7 +57,7 @@ iex> ~C/2 + 7 = #{2 + 7}/
 
 Podemos ver em letra minúscula `~c` interpolando o cálculo, enquanto um sigil de letra maiúscula `~C`  não. Veremos que esta sequência maiúscula / minúscula é um tema comum em toda a construção de sigils.
 
-### Expressões Regulares
+### <a name="expressoes-regulares"></a>Expressões Regulares
 
 O `~r` e `~R` sigils são usados para representar Expressões Regulares. Nós criamos ambos dentro de funções `Regex`. Por exemplo:
 

--- a/pt/lessons/basics/testing.md
+++ b/pt/lessons/basics/testing.md
@@ -85,7 +85,7 @@ ExUnit nos diz exatamente onde nossos asserts falharam, qual era o valor esperad
 
 As vezes pode ser necessário afirmar que um erro foi levantado, podemos fazer isso com `assert_raise`. Vamos ver um exemplo de `assert_raise` na próxima lição sobre Plug.
 
-## Configuração de Teste
+## <a name="configuracao-de-teste"></a>Configuração de Teste
 
 Em alguns casos, pode ser necessária a realização de configuração antes de nossos testes. Para fazer isso acontecer, nós podemos usar o `setup` e `setup_all` macros. `setup` irá ser executado antes de cada teste, e `setup_all` uma vez antes da suite de testes. Espera-se que eles vão retornar uma tupla de `{:ok, state}`, o estado estará disponível para os nossos testes.
 

--- a/pt/lessons/specifics/eex.md
+++ b/pt/lessons/specifics/eex.md
@@ -21,7 +21,7 @@ Do mesmo jeito que Ruby possui ERB e Java JSPs, Elixir tem EEx ou *Embedded Elix
 
 A API EEX suporta trabalhar com cadeias de caracteres e arquivos directamente. A API está dividida em três componentes principais: avaliação simples, definicações de funções, e complilação para AST.
 
-### Avaliação
+### <a name="avaliacao"></a>Avaliação
 
 Usando `eval_string` e `eval_file` podemos realizar uma simples avaliação sobre uma string ou conteúdos de um arquivo. Este é a API mais simples mas lento uma vez que o código é interpretado e não compilado.
 
@@ -30,7 +30,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 "Hi, Sean"
 ```
 
-### Definições
+### <a name="definicoes"></a>Definições
 
 A mais rápida e preferida forma de usar o EEx é embutir nosso template dentro de um módulo assim ele pode ser compilado. Para isso precisamos do nosso template no momento da compilação e dos macros `function_from_string` e `function_from_file`.
 
@@ -49,7 +49,7 @@ iex> Example.greeting("Sean")
 "Hi, Sean"
 ```
 
-### Compilação
+### <a name="compilacao"></a>Compilação
 
 Por último, EEx fornece-nos uma forma para directamente gerar Elixir AST a partir de uma cadeia de caracteres usando `compile_string` ou `compile_file`. Esta API é usada principalmente pelas APIs acima mencionadas, mas está disponível caso deseje implementar seu próprio tratamento de Elixir embutido.
 

--- a/pt/lessons/specifics/ets.md
+++ b/pt/lessons/specifics/ets.md
@@ -20,9 +20,9 @@ Erlang Term Storage, comumente referenciado como ETS, é um poderoso mecanismo d
   - [Correspondências Simples](#correspondencias-simples)
   - [Pesquisa Avançada](#pesquisa-avancada)
 - [Eliminando Dados](#eliminando-dados)
-  - [Removendo Registos](#removendo-registos)
+  - [Removendo Registos](#removendo-registros)
   - [Removendo Tabelas](#removendo-tabelas)
-- [Exemplo de uso do ETS](#exemplo-de-uso-do-ets)
+- [Exemplos de uso do ETS](#exemplos-de-uso-do-ets)
 - [ETS baseado em Disco](#ets-baseado-em-disco)
 
 ## <a name="visao-geral"></a> Visão Geral
@@ -91,7 +91,7 @@ ETS eferece-nos algumas formas convenientes e flexivéis para recuperar nossos d
 O mais eficiente, e ideal, método de recuperar dados é a busca por chave. Enquanto útil, *matching* percore a tabela e deve ser usado com moderação especialmente para grandes conjuntos de dados.
 
 
-### Busca por chave
+### Pesquisa de chave
 
 Dado uma chave, podemos usar `lookup/2` para recuperar todos os registos com esta chave:
 
@@ -165,9 +165,9 @@ iex> :ets.select(:user_lookup, fun)
 
 Quer aprender mais sobre a especificação `match`? Confira a documentação oficial do Erlang para [match_spec](http://www.erlang.org/doc/apps/erts/match_spec.html).
 
-## Eliminando Dasdos
+## Eliminando Dados
 
-### Removendo Registos
+### Removendo Registros
 
 Eliminar termos é tão simples como `insert/2` e `lookup/2`. Com `delete/2` precisamos apenas da nossa tabela e a chave. Isso elimina tanto a chave como o seu respectivo valor:
 

--- a/pt/lessons/specifics/mnesia.md
+++ b/pt/lessons/specifics/mnesia.md
@@ -16,8 +16,8 @@ Mnesia é um sistema de gestão de banco de dados em tempo real de alto tráfego
 - [Nós](#nos)
 - [Iniciando Mnesia](#iniciando-mnesia)
 - [Criando Tabelas](#criando-tabelas)
-- [A Forma Suja](#a-forma-suja)
-- [Operações](#operacoes)
+- [A Maneira Suja](#a-maneira-suja)
+- [Transações](#transacoes)
 
 
 ## <a name="visao-geral"></a> Visão Geral

--- a/pt/lessons/specifics/plug.md
+++ b/pt/lessons/specifics/plug.md
@@ -15,7 +15,7 @@ Se você estiver familiarizado com Ruby, você pode pensar sobre Plug como o Rac
 - [Criando um Plug](#criando-um-plug)
 - [Usando Plug.Router](#usando-plugrouter)
 - [Executando nosso Web App](#executando-nosso-web-app)
-- [Testando Plugs](#testing-plugs)
+- [Testando Plugs](#testando-plugs)
 - [Plugs Disponíveis](#plugs-disponiveis)
 
 ## <a name="instalacao"></a> Instalação
@@ -185,7 +185,7 @@ Agora para executar nossa aplicação, podemos usar:
 $ mix run --no-halt
 ```
 
-## Testando um Plug
+## Testando Plugs
 
 Testes em Plugs são bastante simples, graças ao `Plug.Test`, que inclui uma série de funções convenientes para fazer o teste ser algo fácil.
 


### PR DESCRIPTION
Some words on the summaries has special characters like `ç`, `õ`, `ã`
that Jekyll skips when compiling the markdown and making the anchors.
It prevented the Summary on pages that have headers with these
characters to work and a custom `<a name=""></a>` was necessary to
make the Summary work again.

I also fixed some typos on the summary that also prevented the summary
to work.