### PR TITLE
Make a general view for sigils list

### DIFF
--- a/lessons/basics/sigils.md
+++ b/lessons/basics/sigils.md
@@ -27,10 +27,10 @@ A list of available sigils include:
   - `~c` Generates a character list **with** escaping and interpolation
   - `~R` Generates a regular expression **with no** escaping or interpolation
   - `~r` Generates a regular expression **with** escaping and interpolation
-  - `~S` Generates strings **with no** escaping or interpolation
-  - `~s` Generates string **with** escaping and interpolation
-  - `~W` Generates a list  **with no** escaping or interpolation
-  - `~w` Generates a list **with** escaping and interpolation
+  - `~S` Generates a string **with no** escaping or interpolation
+  - `~s` Generates a string **with** escaping and interpolation
+  - `~W` Generates a word list **with no** escaping or interpolation
+  - `~w` Generates a word list **with** escaping and interpolation
 
 A list of delimiters include:
 


### PR DESCRIPTION
Every noun of the sigils list besides `strings` was singular.
I also think that it might be useful to point that `~W` and  `~w` sigils generate word lists but not character lists or anything else. It should look more clearly this way.