### PR TITLE
Translation of basic/01

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ sections:
       gr: Βασικά
       it: Base
       pl: Podstawy
-      no: Basis
+      no: Grunnleggende
   - tag: advanced
     label:
       en: Advanced

--- a/no/index.md
+++ b/no/index.md
@@ -13,7 +13,7 @@ _Du oppfordres til å delta, samt gi tilbakemeldinger!_
 
 ## Om Elixir
 
-"Elixir er et dynamisk, funksjonelt språk utviklet for å bygge skalerbar og vedlikeholdsvennlige applikasjoner." [elixir-lang.org](http://elixir-lang.org/)
+"Elixir er et dynamisk, funksjonelt språk utviklet for å bygge skalerbare og vedlikeholdsvennlige applikasjoner." [elixir-lang.org](http://elixir-lang.org/)
 
 
 Elixir benytter den bunnsolide ErlangVM til å bygge distribuerte og feiltolerante systemer med lav forsinkelse, rett ut av boksen.

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -16,16 +16,16 @@ Installasjon, grunnleggende typer og operasjoner.
 	- [Interaktiv Modus](#interaktiv-modus)
 - [Grunnleggende Typer](#grunnleggende-typer)
 	- [Integers](#integers)
-	- [Floats](#floats)
-	- [Booleans](#booleans)
+	- [Flyttall (floats)](#flyttall-floats)
+	- [Boolske verdier (booleans)](#boolske-verdier-booleans)
 	- [Atom](#atoms)
-	- [String](#strings)
-- [Grunnleggende Operasjoner](#grunnleggende-operasjoner)
+	- [Strenger (strings)](#strenger-strings)
+- [Grunnleggende Operatorer](#grunnleggende-operatorer)
 	- [Aritmetikk](#artmetikk)
-	- [Boolean](#boolean)
+	- [Boolske Operatorer](#boolske-operatorer-boolean)
 	- [Sammenligning](#sammenligning)
-	- [String interpolasjon](#string-interpolasjon)
-	- [String sammensetning](#string-sammensetning)
+	- [Streng interpolasjon](#string-interpolasjon)
+	- [Streng sammensetning](#string-sammensetning)
 
 ## Installering
 
@@ -66,7 +66,7 @@ iex> 0x1F
 31
 ```
 
-### Floats
+### Flyttall (floats)
 
 Float tall krever et desimal med minimum et siffer. De har 64 bit dobbel nøyaktighet, og støtter `e` for å lage eksponente tall:
 
@@ -80,7 +80,7 @@ iex> 1.0e-10
 ```
 
 
-### Booleans
+### Boolske Verdier (booleans)
 
 Elixir støtter `true` og `false` som boolske verdier. Alt er 'sant', bortsett fra `false` (usant) og `nil` (null):
 
@@ -113,9 +113,9 @@ iex> :true === true
 true
 ```
 
-### Strings
+### Strenger (strings)
 
-Strings i Elixir er UTF-8 innkodet, og skrives mellom doble anførselstegn:
+Strenger i Elixir er UTF-8 innkodet, og skrives mellom doble anførselstegn:
 
 ```elixir
 iex> "Hello"
@@ -124,7 +124,7 @@ iex> "dziękuję"
 "dziękuję"
 ```
 
-Strings støtter linjeskift og avbruddssekvenser:
+Strenger støtter linjeskift og avbruddssekvenser:
 
 ```elixir
 iex> "foo
@@ -134,11 +134,11 @@ iex> "foo\nbar"
 "foo\nbar"
 ```
 
-## Basic Operations
+## Grunnleggende Operatorer
 
-### Arithmetic
+### Aritmetikk
 
-Elixir supports the basic operators `+`, `-`, `*`, and `/` as you would expect.  It's important to notice that `/` will always return a float:
+Elixir støtter de grunnleggende matematiske operatorene `+`, `-`, `*` og `/`. Det er verdt å merke seg at `/` alltid vil returnere et flyttall (float):
 
 ```elixir
 iex> 2 + 2
@@ -151,7 +151,7 @@ iex> 10 / 5
 2.0
 ```
 
-If you need integer division or the division remainder, Elixir comes with two helpful functions to achieve this:
+Elixir har to innebygde funksjoner for å returnere et heltall(integer), eller finne rest i en divisjon:
 
 ```elixir
 iex> div(10, 5)
@@ -160,9 +160,10 @@ iex> rem(10, 3)
 1
 ```
 
-### Boolean
+### Boolske Operatorer (boolean)
 
-Elixir provides the `||`, `&&`, and `!` boolean operators. These support any types:
+Elixir lar deg bruke de boolske operatorene `||`, `&&` og `!`.
+Disse operatorene støtter alle typer:
 
 ```elixir
 iex> -20 || true
@@ -181,7 +182,7 @@ iex> !false
 true
 ```
 
-There are three additional operators whose first argument _must_ be a boolean (`true` and `false`):
+Det er i tillegg tre andre operatorer, hvor første argumentet _må_ være en boolsk verdi (`true` eller `false`):
 
 ```elixir
 iex> true and 42
@@ -196,9 +197,9 @@ iex> not 42
 ** (ArgumentError) argument error
 ```
 
-### Comparison
+### Sammenligning
 
-Elixir comes with all the comparisons operators we're used to: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` and `>`.
+Elixir lar deg bruke en rekke forskjellige operatorer for sammenligning av verdier: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` og `>`.
 
 ```elixir
 iex> 1 > 2
@@ -211,7 +212,7 @@ iex> 2 <= 3
 true
 ```
 
-For strict comparison of integers and floats use `===`:
+For en nøyaktig (strict) sammenligning av heltall og flyttall benytter vi oss av `===`:
 
 ```elixir
 iex> 2 == 2.0
@@ -220,13 +221,14 @@ iex> 2 === 2.0
 false
 ```
 
-An important feature of Elixir is that any two types can be compared, this is particularly useful in sorting.  We don't need to memorize the sort order but it is important to be aware of it:
+En viktig egenskap i Elixir, er at alle typer kan bli sammenlignet med hverandre.
+Dette er spesielt nyttig ved sortering. Vi trenger ikke memorisere sorteringsrekkefølgen, men det er greit å være klar over den:
 
 ```elixir
 number < atom < reference < functions < port < pid < tuple < maps < list < bitstring
 ```
 
-This can lead to some interesting, and valid, comparisons you might not find in other languages:
+Dette kan føre til noen interessante, men gyldige sammenligninger du kanskje ikke finner i andre programmeringsspråk:
 
 ```elixir
 iex> :hello > 999
@@ -235,9 +237,10 @@ iex> {:hello, :world} > [1, 2, 3]
 false
 ```
 
-### String interpolation
+### Streng interpolation
 
 If you've used Ruby, string interpolation in Elixir will look familiar:
+Hvis du noen gang har programmert i Ruby, vil streng interpolasjon i Elixir se veldig kjent ut:
 
 ```elixir
 iex> name = "Sean"

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -11,21 +11,21 @@ Installasjon, grunnleggende typer og operasjoner.
 
 ## Innholdsfortegnelse
 
-- [Innstallering](#setup)
-	- [Installere Elixir ](#install-elixir)
-	- [Interaktiv Modus](#interactive-mode)
-- [Grunnleggende Typer](#basic-types)
+- [Installering](#installering)
+	- [Installere Elixir ](#installere-elixir)
+	- [Interaktiv Modus](#interaktiv-modus)
+- [Grunnleggende Typer](#grunnleggende-typer)
 	- [Integers](#integers)
 	- [Floats](#floats)
 	- [Booleans](#booleans)
 	- [Atom](#atoms)
 	- [String](#strings)
-- [Grunnleggende Operasjoner](#basic-operations)
-	- [Aritmetikk](#arithmetic)
+- [Grunnleggende Operasjoner](#grunnleggende-operasjoner)
+	- [Aritmetikk](#artmetikk)
 	- [Boolean](#boolean)
-	- [Sammenligning](#comparison)
-	- [String interpolasjon](#string-interpolation)
-	- [String sammensetning](#string-concatenation)
+	- [Sammenligning](#sammenligning)
+	- [String interpolasjon](#string-interpolasjon)
+	- [String sammensetning](#string-sammensetning)
 
 ## Installering
 
@@ -33,18 +33,19 @@ Installasjon, grunnleggende typer og operasjoner.
 
 Se guiden hos Elixir-lang.org - [Installere Elixir](http://elixir-lang.org/install.html) på hvordan du installerer Elixir på en rekke forskjellige operativsystemer.
 
-### Interactive Mode
+### Interaktiv Modus
 
-Elixir comes with `iex`, an interactive shell, which allows us to evaluate Elixir expressions as we go.
+Elixir leveres med `iex`, et interaktivt skall som lar oss evaluere Elixirkoder fortløpende.
 
 To get started, let's run `iex`:
+For å start IEx skriver vi `iex` i terminalvinduet:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
 	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
-## Basic Types
+## Grunnleggende Typer
 
 ### Integers
 
@@ -55,7 +56,7 @@ iex> 0xFF
 255
 ```
 
-Support for binary, octal, and hexadecimal numbers comes built in:
+Elixir støtter binære, oktale og heksdesimale tall:
 
 ```elixir
 iex> 0b0110
@@ -68,7 +69,7 @@ iex> 0x1F
 
 ### Floats
 
-In Elixir, float numbers require a decimal after at least one digit; they have 64 bit double precision and support `e` for exponent numbers:
+Float tall krever et desimal med minimum et siffer. De har 64 bit dobbel nøyaktighet, og støtter `e` for å lage eksponente tall:
 
 ```elixir
 iex> 3.41
@@ -82,7 +83,7 @@ iex> 1.0e-10
 
 ### Booleans
 
-Elixir supports `true` and `false` as booleans; everything is truthy except for `false` and `nil`:
+Elixir støtter `true` og `false` som boolske verdier. Alt er 'sant', bortsett fra `false` (usant) og `nil` (null):
 
 ```elixir
 iex> true
@@ -93,7 +94,7 @@ false
 
 ### Atoms
 
-An atom is a constant whose name is their value. If you're familiar with Ruby these are synonymous with Symbols:
+Et atom er en konstant, hvor navnet er dens verdi. Om du er kjent med Ruby, kjenner du disse igjen som Symboler:
 
 ```elixir
 iex> :foo
@@ -102,7 +103,7 @@ iex> :foo == :bar
 false
 ```
 
-NOTE: Booleans `true` and `false` are also the atoms `:true` and `:false` respectively.
+MERK: De boolske verdiene `true` og `false` er også atomer: `:true` og `:false`.
 
 ```elixir
 iex> true |> is_atom
@@ -115,7 +116,7 @@ true
 
 ### Strings
 
-Strings in Elixir are UTF-8 encoded and are wrapped in double quotes:
+Strings i Elixir er UTF-8 innkodet, og skrives mellom doble anførselstegn:
 
 ```elixir
 iex> "Hello"
@@ -124,7 +125,7 @@ iex> "dziękuję"
 "dziękuję"
 ```
 
-Strings support line breaks and escape sequences:
+Strings støtter linjeskift og avbruddssekvenser:
 
 ```elixir
 iex> "foo

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -37,8 +37,7 @@ Se guiden hos Elixir-lang.org - [Installere Elixir](http://elixir-lang.org/insta
 
 Elixir leveres med `iex`, et interaktivt skall som lar oss evaluere Elixirkoder fortløpende.
 
-To get started, let's run `iex`:
-For å start IEx skriver vi `iex` i terminalvinduet:
+For å starte IEx skriver vi `iex` i terminalvinduet:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -27,11 +27,11 @@ Installasjon, grunnleggende typer og operasjoner.
 	- [String interpolasjon](#string-interpolation)
 	- [String sammensetning](#string-concatenation)
 
-## Setup
+## Installering
 
-### Install Elixir
+### Installere Elixir
 
-Installation instructions for each OS can be found on Elixir-lang.org in the [Installing Elixir](http://elixir-lang.org/install.html) guide.
+Se guiden hos Elixir-lang.org - [Installere Elixir](http://elixir-lang.org/install.html) på hvordan du installerer Elixir på en rekke forskjellige operativsystemer.
 
 ### Interactive Mode
 

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -1,0 +1,257 @@
+---
+layout: page
+title: Grunnleggende Elixir
+category: basics
+order: 1
+lang: no
+---
+
+Installasjon, grunnleggende typer og operasjoner.
+
+
+## Innholdsfortegnelse
+
+- [Innstallering](#setup)
+	- [Installere Elixir ](#install-elixir)
+	- [Interaktiv Modus](#interactive-mode)
+- [Grunnleggende Typer](#basic-types)
+	- [Integers](#integers)
+	- [Floats](#floats)
+	- [Booleans](#booleans)
+	- [Atom](#atoms)
+	- [String](#strings)
+- [Grunnleggende Operasjoner](#basic-operations)
+	- [Aritmetikk](#arithmetic)
+	- [Boolean](#boolean)
+	- [Sammenligning](#comparison)
+	- [String interpolasjon](#string-interpolation)
+	- [String sammensetning](#string-concatenation)
+
+## Setup
+
+### Install Elixir
+
+Installation instructions for each OS can be found on Elixir-lang.org in the [Installing Elixir](http://elixir-lang.org/install.html) guide.
+
+### Interactive Mode
+
+Elixir comes with `iex`, an interactive shell, which allows us to evaluate Elixir expressions as we go.
+
+To get started, let's run `iex`:
+
+	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+
+	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	iex>
+
+## Basic Types
+
+### Integers
+
+```elixir
+iex> 255
+255
+iex> 0xFF
+255
+```
+
+Support for binary, octal, and hexadecimal numbers comes built in:
+
+```elixir
+iex> 0b0110
+6
+iex> 0o644
+420
+iex> 0x1F
+31
+```
+
+### Floats
+
+In Elixir, float numbers require a decimal after at least one digit; they have 64 bit double precision and support `e` for exponent numbers:
+
+```elixir
+iex> 3.41
+3.41
+iex> .41
+** (SyntaxError) iex:2: syntax error before: '.'
+iex> 1.0e-10
+1.0e-10
+```
+
+
+### Booleans
+
+Elixir supports `true` and `false` as booleans; everything is truthy except for `false` and `nil`:
+
+```elixir
+iex> true
+true
+iex> false
+false
+```
+
+### Atoms
+
+An atom is a constant whose name is their value. If you're familiar with Ruby these are synonymous with Symbols:
+
+```elixir
+iex> :foo
+:foo
+iex> :foo == :bar
+false
+```
+
+NOTE: Booleans `true` and `false` are also the atoms `:true` and `:false` respectively.
+
+```elixir
+iex> true |> is_atom
+true
+iex> :true |> is_boolean
+true
+iex> :true === true
+true
+```
+
+### Strings
+
+Strings in Elixir are UTF-8 encoded and are wrapped in double quotes:
+
+```elixir
+iex> "Hello"
+"Hello"
+iex> "dziękuję"
+"dziękuję"
+```
+
+Strings support line breaks and escape sequences:
+
+```elixir
+iex> "foo
+...> bar"
+"foo\nbar"
+iex> "foo\nbar"
+"foo\nbar"
+```
+
+## Basic Operations
+
+### Arithmetic
+
+Elixir supports the basic operators `+`, `-`, `*`, and `/` as you would expect.  It's important to notice that `/` will always return a float:
+
+```elixir
+iex> 2 + 2
+4
+iex> 2 - 1
+1
+iex> 2 * 5
+10
+iex> 10 / 5
+2.0
+```
+
+If you need integer division or the division remainder, Elixir comes with two helpful functions to achieve this:
+
+```elixir
+iex> div(10, 5)
+2
+iex> rem(10, 3)
+1
+```
+
+### Boolean
+
+Elixir provides the `||`, `&&`, and `!` boolean operators. These support any types:
+
+```elixir
+iex> -20 || true
+-20
+iex> false || 42
+42
+
+iex> 42 && true
+true
+iex> 42 && nil
+nil
+
+iex> !42
+false
+iex> !false
+true
+```
+
+There are three additional operators whose first argument _must_ be a boolean (`true` and `false`):
+
+```elixir
+iex> true and 42
+42
+iex> false or true
+true
+iex> not false
+true
+iex> 42 and true
+** (ArgumentError) argument error: 42
+iex> not 42
+** (ArgumentError) argument error
+```
+
+### Comparison
+
+Elixir comes with all the comparisons operators we're used to: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` and `>`.
+
+```elixir
+iex> 1 > 2
+false
+iex> 1 != 2
+true
+iex> 2 == 2
+true
+iex> 2 <= 3
+true
+```
+
+For strict comparison of integers and floats use `===`:
+
+```elixir
+iex> 2 == 2.0
+true
+iex> 2 === 2.0
+false
+```
+
+An important feature of Elixir is that any two types can be compared, this is particularly useful in sorting.  We don't need to memorize the sort order but it is important to be aware of it:
+
+```elixir
+number < atom < reference < functions < port < pid < tuple < maps < list < bitstring
+```
+
+This can lead to some interesting, and valid, comparisons you might not find in other languages:
+
+```elixir
+iex> :hello > 999
+true
+iex> {:hello, :world} > [1, 2, 3]
+false
+```
+
+### String interpolation
+
+If you've used Ruby, string interpolation in Elixir will look familiar:
+
+```elixir
+iex> name = "Sean"
+iex> "Hello #{name}"
+"Hello Sean"
+```
+
+### String concatenation
+
+String concatenation uses the `<>` operator:
+
+```elixir
+iex> name = "Sean"
+iex> "Hello " <> name
+"Hello Sean"
+```
+

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -6,7 +6,7 @@ order: 1
 lang: no
 ---
 
-Installasjon, grunnleggende typer og operasjoner.
+Installasjon, grunnleggende typer og operatorer.
 
 
 ## Innholdsfortegnelse
@@ -15,17 +15,17 @@ Installasjon, grunnleggende typer og operasjoner.
 	- [Installere Elixir ](#installere-elixir)
 	- [Interaktiv Modus](#interaktiv-modus)
 - [Grunnleggende Typer](#grunnleggende-typer)
-	- [Integers](#integers)
+	- [Heltall (integers)](#heltall-integers)
 	- [Flyttall (floats)](#flyttall-floats)
 	- [Boolske verdier (booleans)](#boolske-verdier-booleans)
-	- [Atom](#atoms)
+	- [Atomer (atoms)](#atomer-atoms)
 	- [Strenger (strings)](#strenger-strings)
 - [Grunnleggende Operatorer](#grunnleggende-operatorer)
 	- [Aritmetikk](#artmetikk)
-	- [Boolske Operatorer](#boolske-operatorer-boolean)
-	- [Sammenligning](#sammenligning)
-	- [Streng interpolasjon](#string-interpolasjon)
-	- [Streng sammensetning](#string-sammensetning)
+	- [Boolske operatorer](#boolske-operatorer-boolean)
+	- [Sammenligningsoperatorer](#sammenligningsoperatorer)
+	- [Strenginterpolering](#strenginterpolering-string-interpolation)
+	- [Strengsammensetning](#strengsammensetning-string-concatenation)
 
 ## Installering
 
@@ -46,7 +46,7 @@ For å starte IEx skriver vi `iex` i terminalvinduet:
 
 ## Grunnleggende Typer
 
-### Integers
+### Heltall (integers)
 
 ```elixir
 iex> 255
@@ -55,7 +55,7 @@ iex> 0xFF
 255
 ```
 
-Elixir støtter binære, oktale og heksdesimale tall:
+Elixir støtter binære, oktale og heksdesimale heltall:
 
 ```elixir
 iex> 0b0110
@@ -68,7 +68,7 @@ iex> 0x1F
 
 ### Flyttall (floats)
 
-Float tall krever et desimal med minimum et siffer. De har 64 bit dobbel nøyaktighet, og støtter `e` for å lage eksponente tall:
+flyttall krever et desimal med minimum et siffer. De har 64 bit dobbel nøyaktighet, og støtter `e` for å lage eksponenter:
 
 ```elixir
 iex> 3.41
@@ -91,7 +91,7 @@ iex> false
 false
 ```
 
-### Atoms
+### Atomer (Atoms)
 
 Et atom er en konstant, hvor navnet er dens verdi. Om du er kjent med Ruby, kjenner du disse igjen som Symboler:
 
@@ -197,7 +197,7 @@ iex> not 42
 ** (ArgumentError) argument error
 ```
 
-### Sammenligning
+### Sammenligningoperatorer
 
 Elixir lar deg bruke en rekke forskjellige operatorer for sammenligning av verdier: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` og `>`.
 
@@ -222,7 +222,7 @@ false
 ```
 
 En viktig egenskap i Elixir, er at alle typer kan bli sammenlignet med hverandre.
-Dette er spesielt nyttig ved sortering. Vi trenger ikke memorisere sorteringsrekkefølgen, men det er greit å være klar over den:
+Dette er spesielt nyttig ved sortering. Vi trenger ikke memorisere sorteringsrekkefølgen, men det er greit å være kjent med den:
 
 ```elixir
 number < atom < reference < functions < port < pid < tuple < maps < list < bitstring
@@ -237,10 +237,10 @@ iex> {:hello, :world} > [1, 2, 3]
 false
 ```
 
-### Streng interpolation
+### Strenginterpolering (String interpolation)
 
-If you've used Ruby, string interpolation in Elixir will look familiar:
-Hvis du noen gang har programmert i Ruby, vil streng interpolasjon i Elixir se veldig kjent ut:
+Hvis du noen gang har programmert i Ruby, vil strenginterpolering i Elixir
+se kjent ut:
 
 ```elixir
 iex> name = "Sean"
@@ -248,9 +248,9 @@ iex> "Hello #{name}"
 "Hello Sean"
 ```
 
-### String concatenation
+### Strengsammensetning (String concatenation)
 
-String concatenation uses the `<>` operator:
+Strengsammensetning benytter `<>` operatoren:
 
 ```elixir
 iex> name = "Sean"


### PR DESCRIPTION
Changed from "basis" to "grunnleggende" in config file,
fixed minor typo in frontpage index.md
translated basic 01 to norwegian