### PR TITLE
Bump Elixir version in examples (#275)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,3 +100,6 @@ sitemap:
       - '/index.html'
   change_frequency_name: 'change_frequency'
   priority_name: 'priority'
+
+elixir:
+  version: 1.2.3

--- a/cn/lessons/basics/basics.md
+++ b/cn/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Elixir 自带了 `iex` 这样一个交互 shell, 可以让我们随时计算 Eli
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## 基本类型

--- a/es/lessons/basics/basics.md
+++ b/es/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Para empezar, Ejecutamos `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Tipos Básicos

--- a/fr/lessons/basics/basics.md
+++ b/fr/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Pour commencer, lançons `iex`:
 
 	Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-    Interactive Elixir (1.2.3) - press Ctrl+C to exit (type h() ENTER for help)
+    Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Types de base

--- a/it/lessons/basics/basics.md
+++ b/it/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Per cominciare, lanciamo il comando `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Tipi di Base

--- a/jp/lessons/basics/basics.md
+++ b/jp/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Elixirには`iex`という対話シェルが付属しており、入力したそ
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## 基本型

--- a/lessons/advanced/umbrella-projects.md
+++ b/lessons/advanced/umbrella-projects.md
@@ -208,7 +208,7 @@ Consolidated String.Chars
 Consolidated Enumerable
 Consolidated IEx.Info
 Consolidated Inspect
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 
 iex> Datasets.hello
 Hello, I'm the datasets

--- a/lessons/basics/basics.md
+++ b/lessons/basics/basics.md
@@ -40,7 +40,7 @@ To get started, let's run `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Basic Types

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -90,7 +90,7 @@ $ iex --name learner@elixirschool.com
 
 Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 iex(learner@elixirschool.com)> Node.self
 :"learner@elixirschool.com"
 ```

--- a/my/lessons/basics/basics.md
+++ b/my/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Untuk bermula, kita jalankan `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Type Asas

--- a/pl/lessons/basics/basics.md
+++ b/pl/lessons/basics/basics.md
@@ -40,7 +40,7 @@ By ją uruchomić wpisz w wierszu poleceń `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Podstawowe typy danych

--- a/pt/lessons/advanced/umbrella-projects.md
+++ b/pt/lessons/advanced/umbrella-projects.md
@@ -209,7 +209,7 @@ Consolidated String.Chars
 Consolidated Enumerable
 Consolidated IEx.Info
 Consolidated Inspect
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 
 iex> Datasets.hello
 Hello, I'm the datasets

--- a/pt/lessons/basics/basics.md
+++ b/pt/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Para iniciar, executamos `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## <a name="tipos"></a>Tipos Básicos

--- a/pt/lessons/specifics/mnesia.md
+++ b/pt/lessons/specifics/mnesia.md
@@ -89,7 +89,7 @@ $ iex --name learner@elixirschool.com
 
 Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 iex(learner@elixirschool.com)> Node.self
 :"learner@elixirschool.com"
 ```

--- a/ru/lessons/basics/basics.md
+++ b/ru/lessons/basics/basics.md
@@ -39,7 +39,7 @@ lang: ru
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Базовые типы

--- a/sk/lessons/basics/basics.md
+++ b/sk/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Začnime teda jeho spustením príkazu `iex`:
 
 	Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Základné dátové typy

--- a/vi/lessons/basics/basics.md
+++ b/vi/lessons/basics/basics.md
@@ -40,7 +40,7 @@ Elixir đi kèm với `iex`, một shell trực quan, cho phép chúng ta chạy
 
 	Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.2.2) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 
 ## Các kiểu phổ thông
 


### PR DESCRIPTION
I just made another key in Jekyll's config so it will be easy to update Elixir version later. For now, I've set it to 1.2.3.
Changes were made in every existing translation of the following lessons:
- lessons/advanced/umbrella-projects.md;
- lessons/basics/basics.md;
- lessons/specifics/mnesia.md.

I also think we should note the use of  `{{site.elixir.version}}` in CONTRIBUTING.md or somewhere else.