### PR TITLE
Open only current section in the sidebar (#314)

### DIFF
--- a/_assets/javascripts/app.js
+++ b/_assets/javascripts/app.js
@@ -20,7 +20,4 @@ var toggle_section = function() {
 
 $(function() {
   $('.sidebar-nav-header').click(toggle_section);
-
-  $('.advanced .sidebar-nav-header').click();
-  $('.specifics .sidebar-nav-header').click();
 });

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,14 +11,20 @@
     </div>
 
     <nav class="sidebar-nav">
+      {% if page.category == nil %}
+        {% assign current_category = site.sections[0].tag | strip %}
+      {% else %}
+        {% assign current_category = page.category | strip %}
+      {% endif %}
       {% for section in site.sections %}
         {% assign title = section.label[lang] %}
+        {% assign current_tag = section.tag | strip %}
         <div class="sidebar-nav-group {{section.tag}}">
           <div class="sidebar-nav-header">
-            <i class="fa fa-chevron-down"></i>
+            <i class="fa {% if current_category != current_tag %} fa-chevron-right {% else %} fa-chevron-down {% endif %}"></i>
             <span>{{title}}</span>
           </div>
-          <div class="sidebar-nav-list">
+          <div class="sidebar-nav-list" {% if current_category != current_tag %} style="display: none;" {% endif %}>
             {% assign list = site.pages | where: "category", section.tag | where: "lang", lang | sort: "order" %}
             {% for node in list %}
               <div class="sidebar-nav-item">


### PR DESCRIPTION
Earlier sidebar sections were toggled via JS: onload the `click` event was manually triggered on `advanced` and `specifics`.
Now we do not use any JS to set the sections' initial state when the page loads: appropriate CSS is applied in Liquid depending on the current page category. If the page has no category (e.g., we've just visited the index when we heard about Elixir School first time), `basics` is open by default.