### PR TITLE
Set a proper id for the header of social links block

### DIFF
--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,5 +1,5 @@
 <hr />
-<h3 id="string-concatenation">Share This Page</h3>
+<h3 id="social">Share This Page</h3>
 <div class="social__container">
   <div class="social__item">
     <a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ page.url }}&title={{ page.title }}&summary=description&source={{ site.url }}" class="social__icon--linkedin" style="color: #fff; text-decoration: none;"><i class="icon--linkedin"></i></a>


### PR DESCRIPTION
It seems like the old id was just copied from the `basics` lesson.
The new correct id may also become useful for generation of the TOC (#336).