### PR TITLE
Fix minor typo with Map declaration

### DIFF
--- a/cn/lessons/advanced/erlang.md
+++ b/cn/lessons/advanced/erlang.md
@@ -43,10 +43,10 @@ end
 然后我们就可以用 Erlang 的库了：
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 # 区别

--- a/es/lessons/advanced/erlang.md
+++ b/es/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Ahora podemos acceder a nuestra librería Erlang
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Diferencias Notables

--- a/jp/lessons/advanced/erlang.md
+++ b/jp/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 これでErlangライブラリにアクセスできるようになりました:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## 注目すべき違い

--- a/lessons/advanced/erlang.md
+++ b/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Now we can access our Erlang library:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Notable Differences

--- a/my/lessons/advanced/erlang.md
+++ b/my/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Sekarang kita boleh mencapai pustaka Erlang tersebut:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Perbezaan Nyata

--- a/pl/lessons/advanced/erlang.md
+++ b/pl/lessons/advanced/erlang.md
@@ -51,10 +51,10 @@ end
 I teraz mamy dostęp do biblioteki napisanej w erlangu:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Najważniejsze różnice 

--- a/pt/lessons/advanced/erlang.md
+++ b/pt/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Agora podemos acessar nossa biblioteca Erlang:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Diferenças notáveis

--- a/ru/lessons/advanced/erlang.md
+++ b/ru/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Теперь библиотека Erlang доступна:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Заметные различия

--- a/vi/lessons/advanced/erlang.md
+++ b/vi/lessons/advanced/erlang.md
@@ -45,10 +45,10 @@ end
 Và giờ ta có thể truy cập thư viện Erlang:
 
 ```elixir
-png = :png.create(#{:size => {30, 30},
+png = :png.create(%{:size => {30, 30},
                     :mode => {:indexed, 8},
                     :file => file,
-                    :palette => palette}),
+                    :palette => palette})
 ```
 
 ## Những điểm khác biệt cần lưu ý


### PR DESCRIPTION
This is a minor fix in the [Advanced -> Erlang Interoperability](https://elixirschool.com/lessons/advanced/erlang#erlang-packages) section.