### PR TITLE
Japanese translation 1

### DIFF
--- a/jp/lessons/basics/sigils.md
+++ b/jp/lessons/basics/sigils.md
@@ -1,0 +1,168 @@
+---
+layout: page
+title: Sigils
+category: basics
+order: 10
+lang: ja
+---
+
+シギル(sigil)を使う/作る
+
+{% include toc.html %}
+
+## シギルの概要
+
+Elixirには文字列リテラルを表現したり取り扱うための別の構文があります。シギル(sigil)はチルダ`~`から始まり文字が一つそれに続きます。
+Elixirのコアには予め組み込まれたシギルがありますが、それだけではなく言語を拡張したい場合には独自のシギルを作ることもできます。
+
+利用できるシギルのリストには以下のものが含まれます:
+
+  - `~C` **エスケープや埋め込みを含まない**文字のリストを生成する
+  - `~c` **エスケープや埋め込みを含む**文字のリストを生成する
+  - `~R` **エスケープや埋め込みを含まない**正規表現を生成する
+  - `~r` **エスケープや埋め込みを含む**正規表現を生成する
+  - `~S` **エスケープや埋め込みを含まない**文字列を生成する
+  - `~s` **エスケープや埋め込みを含む**文字列を生成する
+  - `~W` **エスケープや埋め込みを含まない**単語のリストを生成する
+  - `~w` **エスケープや埋め込みを含む**単語のリストを生成する
+  
+  デリミタのリストには以下のものが含まれます:
+  
+  - `<...>` カギ括弧のペア
+  - `{...}` 中括弧のペア
+  - `[...]` 大括弧のペア
+  - `(...)` 小括弧のペア
+  - `|...|` パイプ記号のペア
+  - `/.../` スラッシュのペア
+  - `"..."` ダブルクォートのペア
+  - `'...'` シングルクォートのペア
+  
+### 文字のリスト
+  
+`~c`及び`~C`シギルはそれぞれ文字のリストを生成します。例えば:
+ 
+```elixir  
+iex> ~c/2 + 7 = #{2 + 7}/
+'2 + 7 = 9'
+
+iex> ~C/2 + 7 = #{2 + 7}/
+'2 + 7 = #{2 + 7}'
+  
+```
+  
+小文字の`~c`は計算結果を埋め込みますが一方で大文字の`~C`は埋め込まないことがわかります。この大文字/小文字による結果は組み込まれたシギル
+全てに共通するものであることが以降を見ていくとわかるでしょう。
+
+### 正規表現
+
+`~r`及び`~R`シギルはそれぞれ正規表現を生成します。正規表現は動的にも`Regex`関数内で使うためにも生成できます。
+
+例えば:
+
+```elixir
+iex> re = ~r/elixir/
+~/elixir
+
+iex> "Elixir" =~ re
+false
+
+iex> "elixir" =~ re
+true
+```
+
+値が等しいか調べるテストの一番目で`Elixir`は与えられた正規表現と一致しないことがわかります。それは大文字で始まっているからです。
+ElixirはPerl Compatible Regular Expressions (Perl互換正規表現式, PCRE)をサポートしているのでシギルの末尾に`i`を追加することで
+大文字・小文字の区別をしないように指定できます。
+
+```elixir
+iex> re = ~r/elixir/i
+~/elixir
+
+iex> "Elixir" =~ re
+true
+
+iex> "elixir" =~ re
+true
+```
+
+さらに、ElixirはErlangの正規表現ライブラリを元に作られた[Regex](http://elixir-lang.org/docs/stable/elixir/Regex.html)APIを
+提供しています。正規表現シギルを使って`Regex.split/2`を実装してみましょう。
+
+```elixir
+iex> string = "100_000_000"
+"100_000_000"
+
+iex> Regex.split(~r/_/, string)
+["100", "000", "000"]
+```
+
+ご覧のとおり`~r/_/`シギルによってアンダースコアで文字列`"100_000_000"`が分割されました。`Regex.split`はリストを返します。
+
+### 文字列
+
+`~s`及び`~S`シギルは文字列データを生成するのに使われます。例えば：
+
+```elixir
+iex> ~s/the cat in the hat on the mat/
+"the cat in the hat on the mat"
+
+iex> ~S/the cat in the hat on the mat/
+"the cat in the hat on the mat"
+```
+
+ところで違いは何でしょうか。それは文字リストのシギルで既に見たのと同じです。つまり埋め込みとエスケープシーケンスを使うか使わないか、という
+ことです。他の例を見てみましょう:
+
+```elixir
+iex> ~s/welcome to elixir #{String.downcase "school"}/
+"welcome to elixir school"
+
+iex> ~S/welcome to elixir #{String.downcase "school"}/
+"welcome to elixir \#{String.downcase \"school\"}"
+```
+
+### 単語のリスト
+
+単語のリストのシギルは時にはものすごく役立ちます。費やす時間、キーを打つ回数、それと間違いなくコードベースの複雑さを減らすことができます。
+以下に簡単な例を挙げます：
+
+```elixir
+iex> ~w/i love elixir school/
+["i", "love", "elixir", "school"]
+
+iex> ~W/i love elixir school/
+["i", "love", "elixir", "school"]
+```
+
+デリミタ間の、空白で区切られた単語がリストになったのがわかりますね。でも２つの例に違いはありません。そう、違いはまたも埋め込みとエスケープシーケンスを
+使うか使わないかなのです。次の例を見てください:
+
+```elixir
+iex> ~w/i love #{'e'}lixir school/
+["i", "love", "elixir", "school"]
+
+iex> ~W/i love #{'e'}lixir school/
+["i", "love", "\#{'e'}lixir", "school"]
+```
+
+### シギルを作る
+
+Elixirのゴールの一つは拡張性のあるプログラミング言語になることです。独自のシギルを簡単に作ることができても全く驚くには当たりません。
+この例では文字列を大文字に変換するシギルを作ります。Elixirのコアには既にこのための関数(`String.upcase/1`)が用意されているので
+シギルでこの関数をラップします。
+
+```elixir
+
+iex> defmodule MySigils do
+...>   def sigil_u(string, []), do: String.upcase(string)
+...> end
+
+iex> import MySigils
+nil
+
+iex> ~u/elixir school/
+ELIXIR SCHOOL
+```
+
+最初に`MySigils`という名前のモジュールを定義し、そのモジュールの中で`sigil_u`という名前の関数を作ります。既存のシギルの名前空間には
+`~u`シギルはないのでそれを使いましょう。`_u`はチルダの後に文字`u`を使うということを示します。関数定義には2つの引数が必要です。入力とリストです。

--- a/jp/lessons/basics/sigils.md
+++ b/jp/lessons/basics/sigils.md
@@ -2,8 +2,8 @@
 layout: page
 title: Sigils
 category: basics
-order: 10
-lang: ja
+order: 11
+lang: jp
 ---
 
 シギル(sigil)を使う/作る

--- a/jp/lessons/basics/strings.md
+++ b/jp/lessons/basics/strings.md
@@ -1,0 +1,155 @@
+---
+layout: page
+title: Strings
+category: basics
+order: 14
+lang: jp
+---
+
+Elixirにおいて文字列とは何でしょうか。文字のリスト、書記素、コードポイントとは。
+
+{% include toc.html %}
+
+## Elixirの文字列
+
+Elixirにおいて文字列とはバイトのシーケンスに他なりません。例を見てみましょう:
+
+```elixir
+iex> string = <<104,101,108,108,111>>
+"hello"
+```
+
+>註: << >>記法はコンパイラにこれらのシンボルで囲まれた中身はバイト列であることを示します。
+
+## 文字リスト
+
+内部ではElixirの文字列は文字の配列というよりはバイトのシーケンスとして表現されており、Elixirは
+(複数の文字のリストである)文字リストという型を別に持っています。Elixirの文字列はダブルクオートで生成され、一方文字リストは
+シングルクオートで生成されます。
+
+これらの違いは何でしょう？文字リストから得られる個々の値は文字のASCIIコードです。では掘り下げてみましょう:
+
+```elixir
+iex> char_list = 'hello'
+'hello'
+
+iex> Enum.reduce(char_list, "", fn char, acc -> acc <> to_string(char) <> "," end)
+"104,101,108,108,111,"
+```
+
+Elixirでプログラムするときは通常は文字リストを使わず文字列を使います。文字リストがサポートされているのは
+一部のErlangモジュールがそれを必要としているからです。
+
+## 書記素とコードポイント
+
+コードポイントはただ単純にUnicodeの文字で、1バイトまたは2バイトで表現されるものとして差し支えありません。
+例えばチルダやアクセント記号のついた文字: `á, ñ, è` です。
+Stringモジュールにはそれらを得るための2つのメソッド、`graphemes/1` と `codepoints/1`が用意されています。
+例を見てみましょう:
+
+```elixir
+iex> string = "\u0061\u0301"
+"á"
+
+iex> String.codepoints string
+["a", "́"]
+
+iex> String.graphemes string
+["á"]
+```
+
+## 文字列関数
+
+では、Stringモジュールにある重要で役に立つ関数をいくつか見てみましょう。
+
+### `length/1`
+
+書記素の長さを返します。
+
+```elixir
+iex> String.length "Hello"
+5
+```
+
+### `replace/4`
+
+文字列の中の検索パターンを新しい文字列に置き換えて得られた文字列を返します。
+
+```elixir
+iex> String.replace("Hello", "e", "a")
+"Hallo"
+```
+
+### `duplicate/2`
+
+文字列をn回繰り返した文字列を返します。
+
+```elixir
+iex> String.duplicate "Oh my ", 3
+"Oh my Oh my Oh my "
+```
+
+### `split/2`
+
+パターンによって分割された文字列の配列を返します。
+
+```elixir
+iex> String.split("Hello World", " ")
+["Hello", "World"]
+```
+
+## 練習問題
+
+これでもう私たちはStringモジュールを使いこなせるようになったことを示すため2つ簡単な練習問題をやってみましょう。
+
+### アナグラム
+
+文字列Aと文字列Bは、もしAまたはBを並び替えて同じにできるならばアナグラムであると考えられます。例えば:
+A = super
+B = perus
+
+文字列Aを並び替えれば文字列Bにできますし逆もまた同様です。
+
+ではElixirで2つの文字列がアナグラムかどうか調べるにはどうすればいいでしょうか。
+
+一番簡単な解は文字列をアルファベット順に並び替えてそれらが等しいかどうか調べるやり方です。次の例を見てみましょう:
+
+```elixir
+defmodule Anagram do
+  def anagrams?(a, b) when is_binary(a) and is_binary(b) do
+  	sort_string(a) == sort_string(b)
+  end
+
+  def sort_string(string) do
+    string
+    |> String.downcase
+    |> String.graphemes
+    |> Enum.sort
+  end
+end
+```
+
+まずは `anagrams?/2` を見てみましょう。　まず受け取った2つのパラメータがバイナリかそうでないかチェックします。
+これによりパラメータがElixirでの文字列かどうかを見るわけです。
+
+その後、文字列をアルファベット順に並び替える関数を呼び出しますが、その関数では最初に文字列を小文字に変換し、
+次に文字列の書記素の配列を返す `String.graphemes` を使います。単純でしょ？
+
+ではiexで出力を確認しましょう:
+
+```elixir
+iex> Anagram.anagrams?("Hello", "ohell")
+true
+
+iex> Anagram.anagrams?("María", "íMara")
+true
+
+iex> Anagram.anagrams?(3, 5)
+** (FunctionClauseError) no function clause matching in Anagram.anagrams?/2
+    iex:2: Anagram.anagrams?(3, 5)
+```
+
+見ての通り、最後の `anagrams?` の呼び出しでFunctionClauseErrorを起こしています。このエラーは
+2つのバイナリでない引数を受け取る関数がモジュール内にないことを伝えています。そしてそれは我々が
+意図したとおり2つの文字列だけを受け取りそれ以外は受け取らないようになっています。
+

--- a/jp/lessons/basics/strings.md
+++ b/jp/lessons/basics/strings.md
@@ -17,6 +17,10 @@ Elixirにおいて文字列とはバイトのシーケンスに他なりませ�
 ```elixir
 iex> string = <<104,101,108,108,111>>
 "hello"
+
+iex> string = <<227, 129, 147, 227, 130, 147, 227, 129, 171, 227, 129, 161, 227, 130, 143>>
+"こんにちわ"
+
 ```
 
 >註: << >>記法はコンパイラにこれらのシンボルで囲まれた中身はバイト列であることを示します。
@@ -56,6 +60,16 @@ iex> String.codepoints string
 
 iex> String.graphemes string
 ["á"]
+
+iex> string = "\uFF76\uFF9E"    # 半角カタカナ
+"ｶﾞ"
+
+iex> String.codepoints string   # コードポイントは半角の"ｶ"と"ﾞﾞ"にわかれる
+["ｶ", "ﾞ"]
+
+iex> String.graphemes string    # 書記素では1つと数えられる
+["ｶﾞ"]
+
 ```
 
 ## 文字列関数
@@ -68,6 +82,9 @@ iex> String.graphemes string
 
 ```elixir
 iex> String.length "Hello"
+5
+
+iex> String.length "こんにちわ"  # ひらがなでも正しく文字数が返る
 5
 ```
 


### PR DESCRIPTION
Translated Strings session into Japanese.

### Opinion
This time, I just translated as same as the original, however I think multibyte character languages including Japanese should have additional description / examples / notes for the native users.
For example (Japanese small kana):
```elixir
iex> string = "\uFF76\uFF9E"
"ｶﾞ"
iex> String.codepoints string
["ｶ", "ﾞ"]
iex> String.graphemes string
["ｶﾞ"]
iex> String.length string
1
```
(note: I suspect that there is still no de facto standard of Japanese small kana's graphemes/codepoints translations, but Elixir just do it in this way) 

