### PR TITLE
[ID] Replace `rem(x, 2)` with `is_even(x)`

### DIFF
--- a/id/lessons/basics/comprehensions.md
+++ b/id/lessons/basics/comprehensions.md
@@ -78,7 +78,7 @@ List comprehension adalah pemanis sintaks dan mestinya dipakai hanya jika dalam 
 Anda bisa membayangkan filter sebagai semacam guard untuk comprehension.  Ketika sebuah value bernilai `false` atau `nil`, value tersebut dikecualikan dari list yang dihasilkan.  Mari lakukan loop atas sebuah range dan hanya perhatikan bilangan genap:
 
 ```elixir
-iex> for x <- 1..10, rem(x, 2) == 0, do: x
+iex> for x <- 1..10, is_even(x), do: x
 [2, 4, 6, 8, 10]
 ```
 
@@ -86,7 +86,7 @@ Seperti generator, kita bisa gunakan filter rangkap.  Mari coba pada sebuah rang
 
 ```elixir
 iex> for x <- 1..100,
-...>   rem(x, 2) == 0,
+...>   is_even(x),
 ...>   rem(x, 3) == 0, do: x
 [6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96]
 ```


### PR DESCRIPTION
Applied #430 to Indosenian. I actually have no clue how could I miss this one.