### PR TITLE
Add arity to functions in EEx lesson

### DIFF
--- a/es/lessons/specifics/eex.md
+++ b/es/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ La API EEx soporta trabajar con cadenas y archivos directamente. El API se divid
 
 ### Evaluación
 
-Usando `eval_string` y` eval_file` podemos realizar una evaluación simple contra una cadena o contenido de archivos. Esta es la API mas sencilla pero también la más lenta ya que el código es evaluado y no compilado.
+Usando `eval_string/3` y `eval_file/2` podemos realizar una evaluación simple contra una cadena o contenido de archivos. Esta es la API mas sencilla pero también la más lenta ya que el código es evaluado y no compilado.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definiciones
 
-El más rápido, y preferido, método de utilizar EEx es el de insertar nuestra plantilla en un módulo por lo que este puede ser compilado. Para ello necesitamos nuestra plantilla en tiempo de compilación y las macros `function_from_string` y `function_from_file`.
+El más rápido, y preferido, método de utilizar EEx es el de insertar nuestra plantilla en un módulo por lo que este puede ser compilado. Para ello necesitamos nuestra plantilla en tiempo de compilación y las macros `function_from_string/5` y `function_from_file/5`.
 
 Vamos a pasar nuestro saludo a otro archivo y generar una función para nuestra plantilla:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Compilación
 
-Por último, EEx nos proporciona una forma directa de generar Elixir AST de una cadena o archivo usando `compile_string` o `compile_file`. Esta API es utilizada principalmente por las API citadas pero está disponible si desea implementar su propio manejo de Elixir incrustado.
+Por último, EEx nos proporciona una forma directa de generar Elixir AST de una cadena o archivo usando `compile_string/2` o `compile_file/2`. Esta API es utilizada principalmente por las API citadas pero está disponible si desea implementar su propio manejo de Elixir incrustado.
 
 ## Etiquetas
 

--- a/id/lessons/specifics/eex.md
+++ b/id/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ API EEx mendukung pengerjaan dengan string dan file secara langsung.  API terseb
 
 ### Evaluasi
 
-Menggunakan `eval_string` dan `eval_file` kita dapat melakukan evaluasi sederhana terhadap sebuah string atau isi file.  Ini adalah API paling sederhana tetapi yang paling lambat karena code dievaluasi dan bukan dikompilasi.
+Menggunakan `eval_string/3` dan `eval_file/2` kita dapat melakukan evaluasi sederhana terhadap sebuah string atau isi file.  Ini adalah API paling sederhana tetapi yang paling lambat karena code dievaluasi dan bukan dikompilasi.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definisi
 
-Metode paling cepat, dan paling disukai, untuk menggunakan EEx adalah memasukkan template ke dalam sebuah modul sehingga dapat dikompilasi.  Untuk hal ini kita perlukan template kita pada saat kompilasi, bersama macro `function_from_string` dan `function_from_file`.
+Metode paling cepat, dan paling disukai, untuk menggunakan EEx adalah memasukkan template ke dalam sebuah modul sehingga dapat dikompilasi.  Untuk hal ini kita perlukan template kita pada saat kompilasi, bersama macro `function_from_string/5` dan `function_from_file/5`.
 
 Mari pindahkan ucapan salam di atas ke file terpisah dan hasilkan sebuah fungsi untuk template kita:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Kompilasi
 
-Terakhir, EEx memberi kita sebuah cara untuk secara langsung menghasilkan AST Elixir dari sebuah string atau file menggunakan `compile_string` atau `compile_file`. API ini utamanya digunakan oleh API yang sudah dibahas di awal tetapi juga tersedia jika anda ingin mengimplementasi penanganan sendiri terhadap Elixir yang diembed.
+Terakhir, EEx memberi kita sebuah cara untuk secara langsung menghasilkan AST Elixir dari sebuah string atau file menggunakan `compile_string/2` atau `compile_file/2`. API ini utamanya digunakan oleh API yang sudah dibahas di awal tetapi juga tersedia jika anda ingin mengimplementasi penanganan sendiri terhadap Elixir yang diembed.
 
 ## Tag
 

--- a/ko/lessons/specifics/eex.md
+++ b/ko/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ EEx API는 문자열이나 파일을 직접 사용할 수 있게끔 지원합니
 
 ### 평가
 
-`eval_string`와 `eval_file`을 사용해서 문자열이나 파일에 대해서 단순 평가를 할 수 있습니다. 이는 가장 간단한 API이지만, 컴파일 없이 코드가 평가되기 때문에 가장 느립니다.
+`eval_string/3`와 `eval_file/2`을 사용해서 문자열이나 파일에 대해서 단순 평가를 할 수 있습니다. 이는 가장 간단한 API이지만, 컴파일 없이 코드가 평가되기 때문에 가장 느립니다.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### 정의
 
-EEx를 사용하는 방법 중 가장 빠르고, 선호되는 것은 컴파일될 수 있도록 템플릿을 모듈에 삽입하는 것입니다. 이를 위해서는 컴파일 시간에 템플릿과 `function_from_string`, `function_from_file` 매크로가 필요합니다.
+EEx를 사용하는 방법 중 가장 빠르고, 선호되는 것은 컴파일될 수 있도록 템플릿을 모듈에 삽입하는 것입니다. 이를 위해서는 컴파일 시간에 템플릿과 `function_from_string/5`, `function_from_file/5` 매크로가 필요합니다.
 
 그럼 우리의 인사를 파일로 옮기고, 템플릿을 위한 함수를 생성해봅시다:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### 컴파일
 
-마지막으로, EEx는 `compile_string`이나 `compile_file`를 통해 문자열이나 파일에서 Elixir AST를 직접 생성할 방법을 제공합니다. 이 API는 주로 위에서 설명한 API에서 사용하고 있습니다만, 내장 Elixir를 처리를 직접 하고 싶은 경우에도 사용 가능합니다.
+마지막으로, EEx는 `compile_string/2`이나 `compile_file/2`를 통해 문자열이나 파일에서 Elixir AST를 직접 생성할 방법을 제공합니다. 이 API는 주로 위에서 설명한 API에서 사용하고 있습니다만, 내장 Elixir를 처리를 직접 하고 싶은 경우에도 사용 가능합니다.
 
 ## 태그
 

--- a/lessons/specifics/eex.md
+++ b/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ The EEx API supports working with strings and files directly.  The API is divide
 
 ### Evaluation
 
-Using `eval_string` and `eval_file` we can perform a simple evaluation against a string or file contents.  This is the simplest API but the slowest since code is evaluated and not compiled.
+Using `eval_string/3` and `eval_file/2` we can perform a simple evaluation against a string or file contents.  This is the simplest API but the slowest since code is evaluated and not compiled.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definitions
 
-The fastest, and preferred, method of using EEx is to embed our template into a module so it can be compiled.  For this we need our template at compile time, along with the `function_from_string` and `function_from_file` macros.
+The fastest, and preferred, method of using EEx is to embed our template into a module so it can be compiled.  For this we need our template at compile time, along with the `function_from_string/5` and `function_from_file/5` macros.
 
 Let's move our greeting to another file and generate a function for our template:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Compilation
 
-Lastly, EEx provides us a way to directly generate Elixir AST from a string or file using `compile_string` or `compile_file`.  This API is primarily used by the aforementioned APIs but is available should you wish to implement your own handling of embedded Elixir.
+Lastly, EEx provides us a way to directly generate Elixir AST from a string or file using `compile_string/2` or `compile_file/2`.  This API is primarily used by the aforementioned APIs but is available should you wish to implement your own handling of embedded Elixir.
 
 ## Tags
 

--- a/pl/lessons/specifics/eex.md
+++ b/pl/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ API EEx pozwala na pracę zarówno z ciągami znaków jak i plikami. Jest ono po
 
 ### Ewaluacja
 
-Używając funkcji `eval_string` i `eval_file` możemy ewaluować ciągi znaków jak i pliki. Jest to najprostsze podejście, ale też najwolniejsze ponieważ kod jest tylko interpretowany, a nie kompilowany.
+Używając funkcji `eval_string/3` i `eval_file/2` możemy ewaluować ciągi znaków jak i pliki. Jest to najprostsze podejście, ale też najwolniejsze ponieważ kod jest tylko interpretowany, a nie kompilowany.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definiowanie funkcji
 
-Najszybszą, i preferowaną, metodą użycia EEx jest osadzenie szablonu w module dzięki czemu można go skompilować. By to zrobić potrzebujemy w czasie kompilacji modułu pliku z szablonem oraz makr `function_from_string` i `function_from_file`.
+Najszybszą, i preferowaną, metodą użycia EEx jest osadzenie szablonu w module dzięki czemu można go skompilować. By to zrobić potrzebujemy w czasie kompilacji modułu pliku z szablonem oraz makr `function_from_string/5` i `function_from_file/5`.
 
 Przenieśmy nasze powitanie do osobnego pliku, szablonu, i zdefiniujmy dla niego funkcję w module: 
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Kompilacja
 
-W końcu, EEx pozwala nam na bezpośrednie stworzenie AST Elixira z ciągu znaków lub z pliku za pomocą funkcji, odpowiednio `compile_string` i `compile_file`.  Funkcje  te są przede wszystkim używane przez wyżej opisane API, ale są też dostępne jeżeli chcemy stworzyć własną obsługę wbudowanego Elixira.
+W końcu, EEx pozwala nam na bezpośrednie stworzenie AST Elixira z ciągu znaków lub z pliku za pomocą funkcji, odpowiednio `compile_string/2` i `compile_file/2`.  Funkcje  te są przede wszystkim używane przez wyżej opisane API, ale są też dostępne jeżeli chcemy stworzyć własną obsługę wbudowanego Elixira.
 
 ## Znaczniki
 

--- a/pt/lessons/specifics/eex.md
+++ b/pt/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ A API EEX suporta trabalhar com cadeias de caracteres e arquivos directamente. A
 
 ### Avaliação
 
-Usando `eval_string` e `eval_file` podemos realizar uma simples avaliação sobre uma string ou conteúdos de um arquivo. Este é a API mais simples mas lento uma vez que o código é interpretado e não compilado.
+Usando `eval_string/3` e `eval_file/2` podemos realizar uma simples avaliação sobre uma string ou conteúdos de um arquivo. Este é a API mais simples mas lento uma vez que o código é interpretado e não compilado.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definições
 
-A mais rápida e preferida forma de usar o EEx é embutir nosso template dentro de um módulo assim ele pode ser compilado. Para isso precisamos do nosso template no momento da compilação e dos macros `function_from_string` e `function_from_file`.
+A mais rápida e preferida forma de usar o EEx é embutir nosso template dentro de um módulo assim ele pode ser compilado. Para isso precisamos do nosso template no momento da compilação e dos macros `function_from_string/5` e `function_from_file/5`.
 
 Vamos nover nossa saudação para outro arquivo e gerar uma função para nosso template:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Compilação
 
-Por último, EEx fornece-nos uma forma para directamente gerar Elixir AST a partir de uma cadeia de caracteres usando `compile_string` ou `compile_file`. Esta API é usada principalmente pelas APIs acima mencionadas, mas está disponível caso deseje implementar seu próprio tratamento de Elixir embutido.
+Por último, EEx fornece-nos uma forma para directamente gerar Elixir AST a partir de uma cadeia de caracteres usando `compile_string/2` ou `compile_file/2`. Esta API é usada principalmente pelas APIs acima mencionadas, mas está disponível caso deseje implementar seu próprio tratamento de Elixir embutido.
 
 ## Etiquetas
 

--- a/vi/lessons/specifics/eex.md
+++ b/vi/lessons/specifics/eex.md
@@ -16,7 +16,7 @@ The EEx API supports working with strings and files directly.  The API is divide
 
 ### Evaluation
 
-Using `eval_string` and `eval_file` we can perform a simple evaluation against a string or file contents.  This is the simplest API but the slowest since code is evaluated and not compiled.
+Using `eval_string/3` and `eval_file/2` we can perform a simple evaluation against a string or file contents.  This is the simplest API but the slowest since code is evaluated and not compiled.
 
 ```elixir
 iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
@@ -25,7 +25,7 @@ iex> EEx.eval_string "Hi, <%= name %>", [name: "Sean"]
 
 ### Definitions
 
-The fastest, and preferred, method of using EEx is to embed our template into a module so it can be compiled.  For this we need our template at compile time and the `function_from_string` and `function_from_file` macros.
+The fastest, and preferred, method of using EEx is to embed our template into a module so it can be compiled.  For this we need our template at compile time and the `function_from_string/5` and `function_from_file/5` macros.
 
 Let's move our greeting to another file and generate a function for our template:
 
@@ -44,7 +44,7 @@ iex> Example.greeting("Sean")
 
 ### Compilation
 
-Lastly, EEx provides us a way to directly generate Elixir AST from a string or file using `compile_string` or `compile_file`.  This API is primarily used by the aforementioned APIs but is available should you wish to implement your own handling of embedded Elixir.
+Lastly, EEx provides us a way to directly generate Elixir AST from a string or file using `compile_string/2` or `compile_file/2`.  This API is primarily used by the aforementioned APIs but is available should you wish to implement your own handling of embedded Elixir.
 
 ## Tags
 


### PR DESCRIPTION
Right now we have arity in all function mentions. This PR adds arity to function names in EEx lesson.