### PR TITLE
Changing header metadata to show correct information with sharing.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,13 +5,13 @@
 
   <link href="http://gmpg.org/xfn/11" rel="profile">
 
-  <meta name="description" content="Lessons about the Elixir programming language, inspired by Twitter’s Scala School.">
+  <meta name="description" content="{{ site.description[lang] }}">
   <meta name="author" content="Sean Callan">
 
-  <meta property="og:url" content="https://elixirschool.com/">
+  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:site_name" content="ElixirSchool">
   <meta property="og:title" content="{% include title.html %}">
-  <meta property="og:description" content="Lessons about the Elixir programming language, inspired by Twitter’s Scala School.">
+  <meta property="og:description" content="{{ site.description[lang] }}">
   <meta property="og:image" content="{{ site.og_image }}">
 
   <title>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
+{% assign lang = page.lang || site.default_lang %}
 <html lang="en-us">
-
   {% include head.html %}
 
-  {% assign lang = page.lang || site.default_lang %}
   {% if site.rtl_languages contains lang %}
     {% assign body_class = 'rtl' %}
   {% endif %}


### PR DESCRIPTION
Changing `og:url` value to URL of each page will help showing information in Open Graph correctly. (Currently if we share any page to Facebook, we will see same previews because `og:url` points only the main page.)

And changed `description` and `og:description` to show translated description of Elixir School.

### Where can we go further?

We can set `description`s which make summary for each page to make sneak-peeking easy.