### PR TITLE
Add note to `CONTRIBUTING.md` about handling addtions' translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,10 @@
 # Contribution Guidelines
+
+## General
 Please ensure your pull request adheres to the following guidelines:
 
 * New lessons or improvements to existing lessons are welcome.
 * Please check your spelling and grammar.
+* Open an issue to handle translations if adding a new lesson or modifying an existing one. An example can be found [here](https://github.com/doomspork/elixir-school/issues/529)
 
 Thank you for your contributions!


### PR DESCRIPTION
There is currently no documented preference on how best to handle making sure the translations all stay in sync with the main english version. This note gives the example of a simple PR I did [here](https://github.com/doomspork/elixir-school/issues/529) and shows a process I just mimicked from @doomspork. This hopefully will allow us to keep better track of the state of all guides.