### PR TITLE
Add arity to the chunk_by description in basics Enum guide

### DIFF
--- a/lessons/basics/enum.md
+++ b/lessons/basics/enum.md
@@ -50,7 +50,7 @@ There are a few options for `chunk` but we won't go into them, check out [`chunk
 
 ### chunk_by
 
-If we need to group our collection based on something other than size, we can use the `chunk_by` method. It takes a given enumerable and a function, and when the return on that function changes a new group is started and begins the creation of the next:
+If we need to group our collection based on something other than size, we can use the `chunk_by/2` method. It takes a given enumerable and a function, and when the return on that function changes a new group is started and begins the creation of the next:
 
 ```elixir
 iex> Enum.chunk_by(["one", "two", "three", "four", "five"], fn(x) -> String.length(x) end)


### PR DESCRIPTION
This is RE @nscyclone 's comment in [this thread](https://github.com/doomspork/elixir-school/issues/529#issuecomment-233766599) discussing the specific elaboration on Enum.chunk/1. In other areas it has been conventional to reference arity and it was not done here. This clarifies this and removes ambiguity as to whether it could be Enum.chunk_by/3.

I have also updated the issue for translation to note this as well [here](https://github.com/doomspork/elixir-school/issues/529).