### PR TITLE
Corrected typo in Module lesson code snippet

### DIFF
--- a/bg/lessons/basics/modules.md
+++ b/bg/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Without alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/es/lessons/basics/modules.md
+++ b/es/lessons/basics/modules.md
@@ -131,7 +131,7 @@ end
 # Without alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/gr/lessons/basics/modules.md
+++ b/gr/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Χωρίς ψευδώνυμο
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/id/lessons/basics/modules.md
+++ b/id/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Tanpa alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/it/lessons/basics/modules.md
+++ b/it/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Senza alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/jp/lessons/basics/modules.md
+++ b/jp/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # alias を使わない場合
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/ko/lessons/basics/modules.md
+++ b/ko/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # 별칭을 사용하지 않는 경우
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/lessons/basics/modules.md
+++ b/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Without alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/my/lessons/basics/modules.md
+++ b/my/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # tanpa alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/pl/lessons/basics/modules.md
+++ b/pl/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Without alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/pt/lessons/basics/modules.md
+++ b/pt/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Sem alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/ru/lessons/basics/modules.md
+++ b/ru/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Без alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/sk/lessons/basics/modules.md
+++ b/sk/lessons/basics/modules.md
@@ -129,7 +129,7 @@ end
 # bez použitia aliasu
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 

--- a/vi/lessons/basics/modules.md
+++ b/vi/lessons/basics/modules.md
@@ -127,7 +127,7 @@ end
 # Without alias
 
 defmodule Example do
-  def greeting(name), do: Saying.Greetings.basic(name)
+  def greeting(name), do: Sayings.Greetings.basic(name)
 end
 ```
 


### PR DESCRIPTION
The `Saying` module is undefined and inconsistent with the rest of the snippets in the lesson. This updates the snippet to use the `Sayings` module as defined earlier in the lesson.