### PR TITLE
Fix description of UTF-8 encoding. Will need translation.

### DIFF
--- a/lessons/basics/strings.md
+++ b/lessons/basics/strings.md
@@ -45,7 +45,7 @@ When programming in Elixir, we usually use Strings, not char lists. The char lis
 
 ## Graphemes and Codepoints
 
-Codepoints are just simple Unicode characters, which may be represented by one or two bytes. For example, characters with a tilde or accents: `á, ñ, è`. Graphemes consist of multiple codepoints that look as a simple character.
+Codepoints are just simple Unicode characters which are represented by one or more bytes, depending on the UTF-8 encoding. Characters outside of the US ASCII character set will always encode as more than one byte. For example, Latin characters with a tilde or accents (`á, ñ, è`) are typicallyl encoded as two bytes. Characters from Asian languages are often encoded as three or four bytes. Graphemes consist of multiple codepoints that are rendered as a single character.
 
 The String module already provides two methods to obtain them, `graphemes/1` and `codepoints/1`. Let's look at an example:
 

--- a/lessons/basics/strings.md
+++ b/lessons/basics/strings.md
@@ -45,7 +45,7 @@ When programming in Elixir, we usually use Strings, not char lists. The char lis
 
 ## Graphemes and Codepoints
 
-Codepoints are just simple Unicode characters which are represented by one or more bytes, depending on the UTF-8 encoding. Characters outside of the US ASCII character set will always encode as more than one byte. For example, Latin characters with a tilde or accents (`á, ñ, è`) are typicallyl encoded as two bytes. Characters from Asian languages are often encoded as three or four bytes. Graphemes consist of multiple codepoints that are rendered as a single character.
+Codepoints are just simple Unicode characters which are represented by one or more bytes, depending on the UTF-8 encoding. Characters outside of the US ASCII character set will always encode as more than one byte. For example, Latin characters with a tilde or accents (`á, ñ, è`) are typically encoded as two bytes. Characters from Asian languages are often encoded as three or four bytes. Graphemes consist of multiple codepoints that are rendered as a single character.
 
 The String module already provides two methods to obtain them, `graphemes/1` and `codepoints/1`. Let's look at an example:
 


### PR DESCRIPTION
Existing statement that Unicode characters "may be represented by one or two bytes" was factually incorrect.

```elixir
iex> Kernel.byte_size "a"   
1
iex> Kernel.byte_size "á"  # Western European
2
iex> Kernel.byte_size "ğ"  # Turkish
2
iex> Kernel.byte_size "ම" # Sinhala 
3
iex> Kernel.byte_size "😀" # emoji
4
```
