### PR TITLE
Use proper term in 'collections' lesson

### DIFF
--- a/lessons/basics/collections.md
+++ b/lessons/basics/collections.md
@@ -61,7 +61,7 @@ iex> hd [3.14, :pie, "Apple"]
 [:pie, "Apple"]
 ```
 
-In addition to the aforementioned functions, you can use [pattern matching](../pattern-matching/) and the pipe operator `|` to split a list into head and tail; we'll learn more about this pattern in later lessons:
+In addition to the aforementioned functions, you can use [pattern matching](../pattern-matching/) and the cons operator `|` to split a list into head and tail; we'll learn more about this pattern in later lessons:
 
 ```elixir
 iex> [h|t] = [3.14, :pie, "Apple"]


### PR DESCRIPTION
`|` is not a pipe operator, but cons operator. We're discussing this in #600 .

If we merge this - we'll need to update all translations.