### PR TITLE
Added an example demonstrating handling of duplicates in list substraction

### DIFF
--- a/lessons/basics/collections.md
+++ b/lessons/basics/collections.md
@@ -49,6 +49,13 @@ iex> ["foo", :bar, 42] -- [42, "bar"]
 ["foo", :bar]
 ```
 
+Be mindful of duplicate values. For every element on the right, the first occurence of it gets removed from the left:
+
+```elixir
+iex> [1,2,2,3,2,3] -- [1,2,3,2]
+[2, 3]
+```
+
 **Note:** It uses [strict comparison](../basics/#comparison) to match the values.
 
 ### Head / Tail


### PR DESCRIPTION
This tidbit might get people with Ruby background baffled. I'm quite sure other backgrounds might result in similar expectations. Seeing how it's a basic operation, it's better to be aware of this before you start building your knowledge on top of it.

Ruby behaviour:
```ruby
2.2.1 :002 > [1,1,2,3] - [1]
 => [2, 3]
```

Elixir behaviour:
```elixir
iex> [1,1,2,3] -- [1]
[1, 2, 3]
```