### PR TITLE
Fix command in generating child project in Umbrella section

### DIFF
--- a/gr/lessons/advanced/umbrella-projects.md
+++ b/gr/lessons/advanced/umbrella-projects.md
@@ -70,7 +70,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/id/lessons/advanced/umbrella-projects.md
+++ b/id/lessons/advanced/umbrella-projects.md
@@ -70,7 +70,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/jp/lessons/advanced/umbrella-projects.md
+++ b/jp/lessons/advanced/umbrella-projects.md
@@ -70,7 +70,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/ko/lessons/advanced/umbrella-projects.md
+++ b/ko/lessons/advanced/umbrella-projects.md
@@ -77,7 +77,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/lessons/advanced/umbrella-projects.md
+++ b/lessons/advanced/umbrella-projects.md
@@ -70,7 +70,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/pl/lessons/advanced/umbrella-projects.md
+++ b/pl/lessons/advanced/umbrella-projects.md
@@ -74,7 +74,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/pt/lessons/advanced/umbrella-projects.md
+++ b/pt/lessons/advanced/umbrella-projects.md
@@ -71,7 +71,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore

--- a/ru/lessons/advanced/umbrella-projects.md
+++ b/ru/lessons/advanced/umbrella-projects.md
@@ -70,7 +70,7 @@ You can use "mix" to compile it, test it, and more:
 Run "mix help" for more commands.
 
 
-$ mix new datasets
+$ mix new datasets --sup
 
 * creating README.md
 * creating .gitignore


### PR DESCRIPTION
@doomspork 
Do all the projects in `apps` need to be a `sup` project? If then, we would also need to update the command in generating `datasets` app, if we do that on purpose, maybe we would add some explanation on why `datasets` app is an exception?
