### PR TITLE
[JP] Fixed typespec lesson from being hidden for other lessons.

### DIFF
--- a/jp/lessons/advanced/typespec.md
+++ b/jp/lessons/advanced/typespec.md
@@ -3,7 +3,7 @@ layout: page
 title: 仕様と型
 category: advanced
 order: 9
-lang: ja
+lang: jp
 ---
 
 このレッスンでは `@spec` と `@type` の文法について学びます。最初の `@spec` はツールによって解析できるドキュメントを書くための文法をより完全にするものです。二番目の `@type` はコードをより読みやすく理解しやすいものにする手助けをしてくれます。


### PR DESCRIPTION
Even `ja` is [right shorthand for Japanese(as a language, 日本語)](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), All other lessons are using `jp` to indicate Japanese document.

Typespec lessons used `lang: ja` and this made it not visible from other Japanese lessons
![Missing Specifications and Types lesson. It is usually 9th Advanced language](https://cloud.githubusercontent.com/assets/1060635/18816005/bf61c416-837a-11e6-9a62-9e48fdfa2a6f.png)

and there is no other Japanese lessons in Typespec lesson as well.
![_ _elixir_school](https://cloud.githubusercontent.com/assets/1060635/18816008/dd9e226c-837a-11e6-8696-50941b52ce29.png)

Instead of changing all `jp`s into `ja`, I'd like to make small changes to Elixir school in Japanese and let this issue for Japanese contributors.