### PR TITLE
Mnesia guide extensions

### DIFF
--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -182,6 +182,17 @@ iex> data_to_read = fn ->
 iex> Mnesia.transaction(data_to_read)
 {:atomic, [{Person, 6, "Monty Burns", "Businessman"}]}
 ```
+
+Note that if you want to update data, you just need to call `Mnesia.write/1` with the same key as an existing record. Therefore, to update the record for Hans, you can do:
+
+```shell
+iex> Mnesia.transaction(
+...>   fn ->
+...>     Mnesia.write({Person, 5, "Hans Moleman", "Ex-Mayor"})
+...>   end
+...> )
+```
+
 ## Using indices
 
 Mnesia support indices on non-key columns and data can then be queried against

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -113,9 +113,7 @@ We define the columns using the atoms `:id`, `:name`, and `:job`. When we execut
  - `{:atomic, :ok}` if the function executes successfully
  - `{:aborted, Reason}` if the function failed
 
-In particular, if the table already exists, the reason will be of the form
-`{:already_exists, table}` so if we try to create this table a second time,
-we will get:
+In particular, if the table already exists, the reason will be of the form `{:already_exists, table}` so if we try to create this table a second time, we will get:
 
 ```shell
 iex> Mnesia.create_table(Person, [attributes: [:id, :name, :job]])
@@ -195,9 +193,7 @@ iex> Mnesia.transaction(
 
 ## Using indices
 
-Mnesia support indices on non-key columns and data can then be queried against
-those indices. So we can add an index against the `:job` column of the `Person`
-table:
+Mnesia support indices on non-key columns and data can then be queried against those indices. So we can add an index against the `:job` column of the `Person` table:
 
 ```shell
 iex> Mnesia.add_table_index(Person, :job)
@@ -209,17 +205,14 @@ The result is similar to the one returned by `create_table`:
  - `{:atomic, :ok}` if the function executes successfully
  - `{:aborted, Reason}` if the function failed
 
-In particular, if the index already exists, the reason will be of the form
-`{:already_exists, table, attribute_index}` so if we try to add this index a second time,
-we will get:
+In particular, if the index already exists, the reason will be of the form `{:already_exists, table, attribute_index}` so if we try to add this index a second time, we will get:
 
 ```shell
 iex> Mnesia.add_table_index(Person, :job)
 {:aborted, {:already_exists, Person, 4}}
 ```
 
-Once the index is successfully created, we can read against it and retrieve a
-list of all principals:
+Once the index is successfully created, we can read against it and retrieve a list of all principals:
 
 ```shell
 iex> Mnesia.transaction(
@@ -232,13 +225,9 @@ iex> Mnesia.transaction(
 
 ## Match and select
 
-Mnesia supports complex queries to retrieve data from a table in the form of
-matching and ad-hoc select functions.
+Mnesia supports complex queries to retrieve data from a table in the form of matching and ad-hoc select functions.
 
-The `match_object/1` function returns all records that match the given pattern.
-If any of the columns in the table have indices, it can make use of them to make
-the query more efficient. Use the special atom `:_` to identify columns that don't
-participate in the match.
+The `match_object/1` function returns all records that match the given pattern. If any of the columns in the table have indices, it can make use of them to make the query more efficient. Use the special atom `:_` to identify columns that don't participate in the match.
 
 ```shell
 iex> Mnesia.transaction(
@@ -249,9 +238,7 @@ iex> Mnesia.transaction(
 {:atomic, [{Person, 4, "Marge Simpson", "home maker"}]}
 ```
 
-The `select/2` function allows you to specify a custom query using any operator or
-function in the Elixir language (or Erlang for that matter). Let's look at an example
-to select all records that have a key that is greater than 3:
+The `select/2` function allows you to specify a custom query using any operator or function in the Elixir language (or Erlang for that matter). Let's look at an example to select all records that have a key that is greater than 3:
 
 ```shell
 iex> Mnesia.transaction(
@@ -262,19 +249,11 @@ iex> Mnesia.transaction(
 {:atomic, [[7, "Waylon Smithers", "Executive assistant"], [4, "Marge Simpson", "home maker"], [6, "Monty Burns", "Businessman"], [5, "Hans Moleman", "unknown"]]}
 ```
 
-Let's unpack this. The first attribute is the table, `Person`, the second attribute
-is a triple of the form `{match, [guard], [result]}`:
+Let's unpack this. The first attribute is the table, `Person`, the second attribute is a triple of the form `{match, [guard], [result]}`:
 
-- `match` is the same as what you'd pass to the `match_object/1` function; however,
-  note the special atoms `:"$n"` that specify positional parameters that are used
-  by the remainder of the query
-- the `guard` list is a list of tuples that specifies what guard functions to apply,
-  in this case the `:>` (greater than) built in function with the first positional
-  parameter `:"$1"` and the constant `3` as attributes
-- the `result` list is the list of fields that are returned by the query, in the form
-  of positional parameters of the special atom `:"$$"` to reference all fields so
-  you could use `[:"$1", :"$2"]` to return the first two fields or `[:"$$"]` to
-  return all fields
+- `match` is the same as what you'd pass to the `match_object/1` function; however, note the special atoms `:"$n"` that specify positional parameters that are used   by the remainder of the query
+- the `guard` list is a list of tuples that specifies what guard functions to apply,   in this case the `:>` (greater than) built in function with the first positional parameter `:"$1"` and the constant `3` as attributes
+- the `result` list is the list of fields that are returned by the query, in the form of positional parameters of the special atom `:"$$"` to reference all fields so you could use `[:"$1", :"$2"]` to return the first two fields or `[:"$$"]` to return all fields
 
 For more details, see [the Erlang Mnesia documentation for select/2](http://erlang.org/doc/man/mnesia.html#select-2).
 

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -257,14 +257,14 @@ Let's unpack this. The first attribute is the table, `Person`, the second attrib
 
 For more details, see [the Erlang Mnesia documentation for select/2](http://erlang.org/doc/man/mnesia.html#select-2).
 
-## Data initialisation and migration
+## Data initialization and migration
 
 With every software solution, there will come a time when you need to upgrade the software and migrate the data stored in your database. For example, we may want to add an `:age` column to our `Person` table in v2 of our app. We can't create the `Person` table once it's been created but we can transform it. For this we need to know when to transform, which we can do when creating the table. To do this, we can use the `Mnesia.table_info/2` function to retrieve the current structure of the table and the `Mnesia.transform_table/3` function to transform it to the new structure.
 
 The code below does this by implementing the following logic:
 * Create the table with the v2 attributes: `[:id, :name, :job, :age]`
 * Handle the creation result:
-  * `{:atomic, :ok}`: initialise the table by creating indices on `:job` and `:age`
+  * `{:atomic, :ok}`: initialize the table by creating indices on `:job` and `:age`
   * `{:aborted, {:already_exists, Person}}`: check what the attributes are in the current table and act accordingly:
     * if it's the v1 list (`[:id, :name, :job]`), transform the table giving everybody an age of 21 and add a new index on `:age`
     * if it's the v2 list, do nothing, we're good

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -200,7 +200,7 @@ iex> Mnesia.add_table_index(Person, :job)
 {:atomic, :ok}
 ```
 
-The result is similar to the one returned by `create_table`:
+The result is similar to the one returned by `Mnesia.create_table/2`:
 
  - `{:atomic, :ok}` if the function executes successfully
  - `{:aborted, Reason}` if the function failed
@@ -227,7 +227,7 @@ iex> Mnesia.transaction(
 
 Mnesia supports complex queries to retrieve data from a table in the form of matching and ad-hoc select functions.
 
-The `match_object/1` function returns all records that match the given pattern. If any of the columns in the table have indices, it can make use of them to make the query more efficient. Use the special atom `:_` to identify columns that don't participate in the match.
+The `Mnesia.match_object/1` function returns all records that match the given pattern. If any of the columns in the table have indices, it can make use of them to make the query more efficient. Use the special atom `:_` to identify columns that don't participate in the match.
 
 ```shell
 iex> Mnesia.transaction(
@@ -238,7 +238,7 @@ iex> Mnesia.transaction(
 {:atomic, [{Person, 4, "Marge Simpson", "home maker"}]}
 ```
 
-The `select/2` function allows you to specify a custom query using any operator or function in the Elixir language (or Erlang for that matter). Let's look at an example to select all records that have a key that is greater than 3:
+The `Mnesia.select/2` function allows you to specify a custom query using any operator or function in the Elixir language (or Erlang for that matter). Let's look at an example to select all records that have a key that is greater than 3:
 
 ```shell
 iex> Mnesia.transaction(
@@ -251,7 +251,7 @@ iex> Mnesia.transaction(
 
 Let's unpack this. The first attribute is the table, `Person`, the second attribute is a triple of the form `{match, [guard], [result]}`:
 
-- `match` is the same as what you'd pass to the `match_object/1` function; however, note the special atoms `:"$n"` that specify positional parameters that are used   by the remainder of the query
+- `match` is the same as what you'd pass to the `Mnesia.match_object/1` function; however, note the special atoms `:"$n"` that specify positional parameters that are used   by the remainder of the query
 - the `guard` list is a list of tuples that specifies what guard functions to apply,   in this case the `:>` (greater than) built in function with the first positional parameter `:"$1"` and the constant `3` as attributes
 - the `result` list is the list of fields that are returned by the query, in the form of positional parameters of the special atom `:"$$"` to reference all fields so you could use `[:"$1", :"$2"]` to return the first two fields or `[:"$$"]` to return all fields
 


### PR DESCRIPTION
Extended the Mnesia page as a result of using it to understand how to use Mnesia in Elixir. The changes include:
- A short note on what the call to `Mnesia.create_table/2` returns when the table already exists,
- A short note on how to update existing data entries in the `Transactions` section,
- A new section on indices and how to use them,
- A new section on `Mnesia.match_object/1` and `Mnesia.select/2` to explain how to perform complex queries, in particular attempting to explain the special atoms used by those two functions,
- A new section on data initialisation and migration.
