### PR TITLE
Use pessimistic versioning to allow 2.3.x versions of ruby.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.0'
+ruby '~> 2.3.0'
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass'


### PR DESCRIPTION
Fixes #739