### PR TITLE
Use relative URLs in index translation links

### DIFF
--- a/bg/index.md
+++ b/bg/index.md
@@ -10,18 +10,18 @@ lang: bg
 
 Преведен и на [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][my], [Українською][uk], [한국어][ko], [L'italiano][it] и други.
 
-  [cn]: {{ site.url }}/cn/
-  [es]: {{ site.url }}/es/
-  [it]: {{ site.url }}/it/
-  [jp]: {{ site.url }}/jp/
-  [ko]: {{ site.url }}/ko/
-  [pl]: {{ site.url }}/pl/
-  [pt]: {{ site.url }}/pt/
-  [ru]: {{ site.url }}/ru/
-  [sk]: {{ site.url }}/sk/
-  [vi]: {{ site.url }}/vi/
-  [my]: {{ site.url }}/my/
-  [uk]: {{ site.url }}/uk/
+  [cn]: /cn/
+  [es]: /es/
+  [it]: /it/
+  [jp]: /jp/
+  [ko]: /ko/
+  [pl]: /pl/
+  [pt]: /pt/
+  [ru]: /ru/
+  [sk]: /sk/
+  [vi]: /vi/
+  [my]: /my/
+  [uk]: /uk/
 
 _Обратната връзка и участие са желателни!_
 

--- a/index.md
+++ b/index.md
@@ -10,19 +10,19 @@ Lessons about the Elixir programming language, inspired by Twitter's [Scala Scho
 
 Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][my], [Українською][uk], [한국어][ko], [L'italiano][it], [Deutsch](de) and other.
 
-  [cn]: {{ site.url }}/cn/
-  [es]: {{ site.url }}/es/
-  [it]: {{ site.url }}/it/
-  [jp]: {{ site.url }}/jp/
-  [ko]: {{ site.url }}/ko/
-  [pl]: {{ site.url }}/pl/
-  [pt]: {{ site.url }}/pt/
-  [ru]: {{ site.url }}/ru/
-  [sk]: {{ site.url }}/sk/
-  [vi]: {{ site.url }}/vi/
-  [my]: {{ site.url }}/my/
-  [uk]: {{ site.url }}/uk/
-  [de]: {{ site.url }}/de/
+  [cn]: /cn/
+  [es]: /es/
+  [it]: /it/
+  [jp]: /jp/
+  [ko]: /ko/
+  [pl]: /pl/
+  [pt]: /pt/
+  [ru]: /ru/
+  [sk]: /sk/
+  [vi]: /vi/
+  [my]: /my/
+  [uk]: /uk/
+  [de]: /de/
 
 _Your feedback and participation is encouraged!_
 

--- a/uk/index.md
+++ b/uk/index.md
@@ -10,12 +10,12 @@ lang: uk
 
 Доступно також [Việt ngữ][vi], [汉语][cn], [Español][es], [日本語][jp], [Português][pt], [Bahasa Melayu][my] та інших мовах.
 
-[cn]: {{ site.url }}/cn/
-[es]: {{ site.url }}/es/
-[jp]: {{ site.url }}/jp/
-[pt]: {{ site.url }}/pt/
-[vi]: {{ site.url }}/vi/
-[my]: {{ site.url }}/my/
+[cn]: /cn/
+[es]: /es/
+[jp]: /jp/
+[pt]: /pt/
+[vi]: /vi/
+[my]: /my/
 
 _Зворотній зв'язок та допомога завжди потрібні!_
 


### PR DESCRIPTION
Right now when using local site you may unintentionally get to https://elixirschool.com/ via those links.

That's a minor inconvenience, but this fix may be helpful to save some time on debugging. 

Also, looks like we have those links on only two translations - other translations just don't have this block. Any ideas whether it's intentional?