### PR TITLE
Bump Elixir version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,7 +131,7 @@ sitemap:
   priority_name: 'priority'
 
 elixir:
-  version: 1.3.2
+  version: 1.3.4
 
 erlang:
   OTP: 20


### PR DESCRIPTION
`1.3.4` is the [latest](https://github.com/elixir-lang/elixir/releases/tag/v1.3.4) release.