### PR TITLE
Remove unnecessary spaces.

### DIFF
--- a/bg/lessons/basics/basics.md
+++ b/bg/lessons/basics/basics.md
@@ -44,7 +44,7 @@ iex> 2+3 == 5
 true
 iex> String.length("The quick brown fox jumps over the lazy dog")
 43
- ```
+```
 
 Не се притеснявайте, ако не разбирате всичко, надяваме се просто да схванете идеята.
 

--- a/gr/lessons/basics/basics.md
+++ b/gr/lessons/basics/basics.md
@@ -44,7 +44,7 @@ iex> 2+3 == 5
 true
 iex> String.length("The quick brown fox jumps over the lazy dog")
 43
- ```
+```
 
 Μην ανησυχείτε αν δεν καταλαβαίνετε όλες τις εκφράσεις ακόμα, αλλά λογικά θα πιάνετε το νόημα.
 

--- a/jp/lessons/basics/basics.md
+++ b/jp/lessons/basics/basics.md
@@ -44,7 +44,7 @@ iex> 2+3 == 5
 true
 iex> String.length("The quick brown fox jumps over the lazy dog")
 43
- ```
+```
 
 それぞれの式をまだ理解していなくても心配することはありませんが、うまくいけばやり方は分かるでしょう。
 

--- a/ru/lessons/basics/basics.md
+++ b/ru/lessons/basics/basics.md
@@ -45,7 +45,7 @@ iex> 2+3 == 5
 true
 iex> String.length("The quick brown fox jumps over the lazy dog")
 43
- ```
+```
 
 Не стоит волноваться, если пока вы поняли не все выражения.
 

--- a/uk/lessons/basics/basics.md
+++ b/uk/lessons/basics/basics.md
@@ -44,7 +44,7 @@ iex> 2+3 == 5
 true
 iex> String.length("The quick brown fox jumps over the lazy dog")
 43
- ```
+```
 
 Не біда якщо ви поки не розумієте деталей кожного виразу. До ніх ми ще дійдемо.
 


### PR DESCRIPTION
These spaces break markup on website pages.

e.g:

![image](https://cloud.githubusercontent.com/assets/11492412/19900401/0765dd8e-a06c-11e6-9bdb-8b444b7750ce.png)

I checked all `lessons/basics/basics.md` files and if it's necessary I can check all.