### PR TITLE
Capitalize `behaviours` lesson in listing

### DIFF
--- a/lessons/advanced/behaviours.md
+++ b/lessons/advanced/behaviours.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: behaviours
+title: Behaviours
 category: advanced
 order: 10
 lang: en


### PR DESCRIPTION
Self-explanatory. It was not listing with a capitalized title like the rest of the Advanced lessons in its section.