### PR TITLE
update GenStage lesson introduction

### DIFF
--- a/lessons/advanced/gen-stage.md
+++ b/lessons/advanced/gen-stage.md
@@ -44,7 +44,7 @@ Now that we've covered the roles within GenStage let's start on our application.
 
 ## Getting Started
 
-In this example we'll be constructing a GenStage application that emits numbers, sort out the prime numbers, and finally print them.
+In this example we'll be constructing a GenStage application that emits numbers, sort out the even numbers, and finally print them.
 
 For our application we'll use all three GenStage roles.  Our producer will be responsible for counting and emits numbers.  We'll use a producer-consumer to filter out only the even numbers and later respond to demand from downsteam.  Last we'll build a consumer to display the remaining numbers for us.
 


### PR DESCRIPTION
The new `GenStage` tutorial is great! But it promises to find the primes up to who knows how high of a number, and the sample code checks for even numbers.

In lieu of a good solution to reverse-engineer primes - unless I have misunderstood the description of course - I changed the introduction text to match the example code.

I can submit a more computationally expensive function than checking for even integers if necessary, but this seemed like a good stopgap so that the code isn't misleading.

Thanks!