### PR TITLE
Remove compiler warning

### DIFF
--- a/lessons/advanced/escripts.md
+++ b/lessons/advanced/escripts.md
@@ -62,8 +62,7 @@ defmodule ExampleApp.CLI do
   end
 
   defp response({opts, word}) do
-    if opts[:upcase], do: word = String.upcase(word)
-    word
+    if opts[:upcase], do: String.upcase(word)
   end
 end
 ```


### PR DESCRIPTION
Compiling 1 file (.ex)
warning: the variable "word" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/build_basics.ex:19