### PR TITLE
Fix the incorrect lesson order in translations

### DIFF
--- a/fr/lessons/basics/functions.md
+++ b/fr/lessons/basics/functions.md
@@ -2,7 +2,7 @@
 layout: page
 title: Fonctions
 category: basics
-order: 7
+order: 6
 lang: fr
 ---
 

--- a/id/lessons/basics/functions.md
+++ b/id/lessons/basics/functions.md
@@ -2,7 +2,7 @@
 layout: page
 title: Fungsi
 category: basics
-order: 7
+order: 6
 lang: id
 ---
 

--- a/id/lessons/basics/pipe-operator.md
+++ b/id/lessons/basics/pipe-operator.md
@@ -2,7 +2,7 @@
 layout: page
 title: Operator pipe
 category: basics
-order: 6 
+order: 7
 lang: id
 ---
 


### PR DESCRIPTION
The French translation had two seventh lessons in `basics`. In the Indonesian translation the sixth and the seventh lessons were swapped.