### PR TITLE
[PT] Fix a little typo in pt version

### DIFF
--- a/pt/lessons/basics/enum.md
+++ b/pt/lessons/basics/enum.md
@@ -126,7 +126,7 @@ A outra opção nos permite prover uma função de ordenação:
 ```elixir
 # with our function
 iex> Enum.sort([%{:val => 4}, %{:val => 1}], fn(x, y) -> x[:val] > y[:val] end)
-[%{count: 4}, %{count: 1}]
+[%{val: 4}, %{val: 1}]
 
 # without
 iex> Enum.sort([%{:count => 4}, %{:count => 1}])


### PR DESCRIPTION
- Little typo in atoms ```Enum.sort``` example.