### PR TITLE
Fix password error function order in validate_password_confirmation (ref #826)

### DIFF
--- a/lessons/specifics/ecto.md
+++ b/lessons/specifics/ecto.md
@@ -297,10 +297,10 @@ defmodule ExampleApp.User do
   defp validate_password_confirmation(changeset) do
     case get_change(changeset, :password_confirmation) do
       nil ->
-        password_mismatch_error(changeset)
+        password_incorrect_error(changeset)
       confirmation ->
         password = get_field(changeset, :password)
-        if confirmation == password, do: changeset, else: password_incorrect_error(changeset)
+        if confirmation == password, do: changeset, else: password_mismatch_error(changeset)
     end
   end
 


### PR DESCRIPTION
password_incorrect_error and password_mismatch_error are called in opposite order of where they should have been called in the get_change case.  This fix reorders them correctly.