### PR TITLE
Link to style guide in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,6 @@ Please ensure your pull request adheres to the following guidelines:
 * New lessons or improvements to existing lessons are welcome.
 * Please check your spelling and grammar.
 * Open an issue to handle translations if adding a new lesson or modifying an existing one. An example can be found [here](https://github.com/doomspork/elixir-school/issues/529)
+* Please adhere to our [style guide](https://github.com/doomspork/elixir-school/wiki/Lesson-Styleguide)
 
 Thank you for your contributions!


### PR DESCRIPTION
When responding to [this issue](https://github.com/doomspork/elixir-school/issues/828) I realized the style guide I suggested to consult was not linked to in CONTRIBUTING.md, and figured this was a no-brainer to help new contributors get started and not have minor issues that slow the merge flow.