### PR TITLE
fix: mislabeled lang in pl specs

### DIFF
--- a/pl/lessons/advanced/typespec.md
+++ b/pl/lessons/advanced/typespec.md
@@ -3,7 +3,7 @@ layout: page
 title: Specyfikacje i typy
 category: advanced
 order: 9
-lang: en
+lang: pl
 ---
 
 W tej lekcji przyjrzymy się składni `@spec` i `@type`. Pierwszy służy jako dodatek do składni, który pozwala na analizę kodu przez automatyczne narzędzia. Drugi pozwala na pisanie kodu, który jest bardziej czytelny i prostszy w zrozumieniu.


### PR DESCRIPTION
The current sidebar on the site includes the Polish specs and types link.