### PR TITLE
Use relative protocol link for license image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Elixir School [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+# Elixir School [![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 > Lessons about the Elixir programming language, inspired by Twitter's [Scala School](http://twitter.github.io/scala_school/).
 

--- a/bg/index.md
+++ b/bg/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: bg
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Уроци за езика за програмиране Elixir, вдъхновени от [Scala School](http://twitter.github.io/scala_school/) на Twitter.
 

--- a/cn/index.md
+++ b/cn/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: cn
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Elixir 基础知识教程，受 Twitter 的 [Scala School](http://twitter.github.io/scala_school/) 启发编写。
 

--- a/de/index.md
+++ b/de/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: de
 ---
 
-[![Lizenz](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![Lizenz](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Lektionen zur Elixir Programmiersprache, inspiriert durch Twitters [Scala School](http://twitter.github.io/scala_school/).
 

--- a/es/index.md
+++ b/es/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: es
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Las lecciones de Fundamentos de Elixir están inspiradas en [Scala School](http://twitter.github.io/scala_school/) de Twitter.
 

--- a/fr/index.md
+++ b/fr/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: fr
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Leçons sur le langage de programmation Elixir, inspiré de la [Scala School](http://twitter.github.io/scala_school/) de Twitter.
 

--- a/gr/index.md
+++ b/gr/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: gr
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Μαθήματα της γλώσσας προγραμματισμού Elixir, εμπνευσμένα από το [Scala School](http://twitter.github.io/scala_school/) του Twitter.
 

--- a/id/index.md
+++ b/id/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: id
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Pelajaran tentang bahasa pemrograman Elixir, terinspirasi oleh [Scala School](http://twitter.github.io/scala_school/) dari Twitter.
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: en
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Lessons about the Elixir programming language, inspired by Twitter's [Scala School](http://twitter.github.io/scala_school/).
 

--- a/it/index.md
+++ b/it/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: it
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Lezioni sul linguaggio di programmazione Elixir, ispirato a [Scala School](http://twitter.github.io/scala_school/) di Twitter.
 

--- a/jp/index.md
+++ b/jp/index.md
@@ -4,7 +4,7 @@ title: Elixir School 日本語訳
 lang: jp
 ---
 
-[![ライセンス](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![ライセンス](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 この、Elixir基礎レッスンは、Twitterの [Scala School](http://twitter.github.io/scala_school/)にインスパイアされたものです。
 

--- a/ko/index.md
+++ b/ko/index.md
@@ -4,7 +4,7 @@ title: Elixir School 한국어판
 lang: ko
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 프로그래밍 언어 Elixir 강의, Twitter의 [Scala School](http://twitter.github.io/scala_school/)에서 아이디어를 받아 만들었습니다.
 

--- a/my/index.md
+++ b/my/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: my
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Pelajaran mengenai bahasa aturcara Elixir, diinspirasikan oleh [Sekolah Scala Twitter](http://twitter.github.io/scala_school/).
 

--- a/no/index.md
+++ b/no/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: no
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Leksjoner i programmeringsspråket Elixir, inspirert av Twitters [Scala Skole](http://twitter.github.io/scala_school/).
 

--- a/pl/index.md
+++ b/pl/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: pl
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Lekcje programowania w języku Elixir, inspirowane lekcjami Twittera [Scala School](http://twitter.github.io/scala_school/). 
 

--- a/pt/index.md
+++ b/pt/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: pt
 ---
 
-[![Licença](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![Licença](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 As lições sobre a linguagem de programação Elixir foram inspiradas na [Scala School](http://twitter.github.io/scala_school/) do Twitter.
 

--- a/ru/index.md
+++ b/ru/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: ru
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Базовые знания о языке Elixir, навеяно [Scala School](http://twitter.github.io/scala_school/) от Twitter.
 

--- a/sk/index.md
+++ b/sk/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: sk
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Lekcie o programovacom jazyku Elixir, inšpirované [Scala School](http://twitter.github.io/scala_school/) od Twitteru.
 

--- a/tr/index.md
+++ b/tr/index.md
@@ -4,7 +4,7 @@ title: Elixir Okulu
 lang: tr
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Elixir programlama dili dersleri, Twitter'ın [Scala Okulu](http://twitter.github.io/scala_school/)'ndan esinlenmiştir.
 

--- a/uk/index.md
+++ b/uk/index.md
@@ -4,7 +4,7 @@ title: Elixir School
 lang: uk
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Навчальні матеріали про мову программування Elixir, навіяні [Scala School](http://twitter.github.io/scala_school/) від Твіттера.
 

--- a/vi/index.md
+++ b/vi/index.md
@@ -4,7 +4,7 @@ title: Elixir School (Việt ngữ)
 lang: vi
 ---
 
-[![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](//img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 Các bài học về ngôn ngữ lập trình Elixir, lấy cảm hứng từ [Scala School](http://twitter.github.io/scala_school/) của Twitter.
 


### PR DESCRIPTION
Right now we're linking http image from the https site ( https://elixirschool.com ).

This PR changes it to use the same protocol for image as ws used to access the page.