### PR TITLE
Fix 'ensure_authed_acces' typo in guardian lesson

### DIFF
--- a/gr/lessons/libraries/guardian.md
+++ b/gr/lessons/libraries/guardian.md
@@ -140,7 +140,7 @@ pipeline :maybe_browser_auth do
   plug Guardian.Plug.LoadResource
 end
 
-pipeline :ensure_authed_acces do
+pipeline :ensure_authed_access do
   plug Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler}
 end
 ```

--- a/lessons/libraries/guardian.md
+++ b/lessons/libraries/guardian.md
@@ -140,7 +140,7 @@ pipeline :maybe_browser_auth do
   plug Guardian.Plug.LoadResource
 end
 
-pipeline :ensure_authed_acces do
+pipeline :ensure_authed_access do
   plug Guardian.Plug.EnsureAuthenticated, %{"typ" => "access", handler: MyApp.HttpErrorHandler}
 end
 ```


### PR DESCRIPTION
Thanks to @nscyclone who pointed me to this problem while reviewing the translation of this lesson.

This PR fixes a typo in listing. While we declare `ensure_authed_acces` pipeline, we use `ensure_authed_acces*s*` then.