### PR TITLE
Bump Elixir version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -145,7 +145,7 @@ sitemap:
   priority_name: 'priority'
 
 elixir:
-  version: 1.3.4
+  version: 1.4.0
 
 erlang:
   OTP: 19


### PR DESCRIPTION
`1.4.0` was [released](https://github.com/elixir-lang/elixir/releases/tag/v1.4.0) 2 days ago.