### PR TITLE
[PL] Fix a typo in the `specifics/eex` lesson translation

### DIFF
--- a/pl/lessons/specifics/eex.md
+++ b/pl/lessons/specifics/eex.md
@@ -76,6 +76,6 @@ iex> EEx.eval_string "Hi, <%= @name %>", assigns: [name: "Sean"]
 "Hi, Sean"
 ```
 
-Przypisania obecne w `EEx.SmartEngine` są bardzo przydatne ponieważ pozwalają wprowadzać zmiany bez konieczności rekompilacji szblonu.
+Przypisania obecne w `EEx.SmartEngine` są bardzo przydatne ponieważ pozwalają wprowadzać zmiany bez konieczności rekompilacji szablonu.
 
 Zainteresowany stworzeniem własnego silnika? Sprawdź jak działa [`EEx.Engine`](http://elixir-lang.org/docs/stable/eex/EEx.Engine.html) by zobaczyć co jest wymagane. 


### PR DESCRIPTION
@Koziolek, could you check this one, please?