### PR TITLE
Remove References to GenEvent

### DIFF
--- a/lessons/advanced/otp-concurrency.md
+++ b/lessons/advanced/otp-concurrency.md
@@ -8,7 +8,7 @@ lang: en
 
 We've looked at the Elixir abstractions for concurrency but sometimes we need greater control and for that we turn to the OTP behaviors that Elixir is built on.
 
-In this lesson we'll focus on two important pieces: GenServers and GenEvents.
+In this lesson we'll focus on the biggest piece: GenServers.
 
 {% include toc.html %}
 
@@ -150,78 +150,3 @@ iex> SimpleQueue.queue
 ```
 
 For more information check out the official [GenServer](http://elixir-lang.org/docs/stable/elixir/GenServer.html#content) documentation.
-
-## GenEvent
-
-We learned that GenServers are processes that can maintain state and handle synchronous and asynchronous requests.  So what is a GenEvent?  GenEvents are generic event managers that receive incoming events and notify subscribed consumers.  They provide a mechanism for dynamically adding and removing handlers to flows of events.
-
-### Handling Events
-
-The most important callback in GenEvents as you can imagine is `handle_event/2`.  This receives the event and the handler's current state and is expected to return a tuple: `{:ok, state}`.
-
-To demonstrate the GenEvent functionality let's start by creating two handlers, one to keep a log of messages and the other to persist them (theoretically):
-
-```elixir
-defmodule LoggerHandler do
-  use GenEvent
-
-  def handle_event({:msg, msg}, messages) do
-    IO.puts "Logging new message: #{msg}"
-    {:ok, [msg|messages]}
-  end
-end
-
-defmodule PersistenceHandler do
-  use GenEvent
-
-  def handle_event({:msg, msg}, state) do
-    IO.puts "Persisting log message: #{msg}"
-
-    # Save message
-
-    {:ok, state}
-  end
-end
-```
-
-### Calling Handlers
-
-In addition to `handle_event/2` GenEvents also support `handle_call/2` among other callbacks.  With `handle_call/2` we can handle specific synchronous messages with our handler.
-
-Let's update our `LoggerHandler` to include a method for retrieving the current message log:
-
-```elixir
-defmodule LoggerHandler do
-  use GenEvent
-
-  def handle_event({:msg, msg}, messages) do
-    IO.puts "Logging new message: #{msg}"
-    {:ok, [msg|messages]}
-  end
-
-  def handle_call(:messages, messages) do
-    {:ok, Enum.reverse(messages), messages}
-  end
-end
-```
-
-### Using GenEvents
-
-With our handlers ready to go we need to familiarize ourselves with a few of GenEvent's functions.  The three most important functions are: `add_handler/3`, `notify/2`, and `call/4`.  These allow us to add handlers, broadcast new messages, and call specific handler functions respectively.
-
-If we put it all together we can see our handlers in action:
-
-```elixir
-iex> {:ok, pid} = GenEvent.start_link([])
-iex> GenEvent.add_handler(pid, LoggerHandler, [])
-iex> GenEvent.add_handler(pid, PersistenceHandler, [])
-
-iex> GenEvent.notify(pid, {:msg, "Hello World"})
-Logging new message: Hello World
-Persisting log message: Hello World
-
-iex> GenEvent.call(pid, LoggerHandler, :messages)
-["Hello World"]
-```
-
-See the official [GenEvent](http://elixir-lang.org/docs/stable/elixir/GenEvent.html#content) documentation for a complete list of callbacks and GenEvent functionality.


### PR DESCRIPTION
This removes all reference to GenEvent. From my grepping, it was contained to this single lesson. If anyone else has spotted any other instances, feel free to let me know and I will update.

I would have just done the PR's to remove it all from the languages that have the lesson for translations too but it requires changing the first reference from singular to plural so I would fail that pretty hard I imagine.

I know issue #944 goes into versioning and keeping things up, @nscyclone @brain-geek @devleoper @Koziolek @gemantzu or anyone else feel free to handle the translation side of tracking this, or if you just want to go the typical issue route I have opened one [here](link) but will close it if a new setup is desired.