### PR TITLE
Fix JWT name error in VI translation

### DIFF
--- a/vi/lessons/libraries/guardian.md
+++ b/vi/lessons/libraries/guardian.md
@@ -6,7 +6,7 @@ order: 1
 lang: vi
 ---
 
-[Guardian](https://github.com/ueberauth/guardian) là một thư viện xác thực danh tính người dùng được sử dụng rộng rãi dựa trên chuẩn [JWT](https://jwt.io/) (Javascript Web Token).
+[Guardian](https://github.com/ueberauth/guardian) là một thư viện xác thực danh tính người dùng được sử dụng rộng rãi dựa trên chuẩn [JWT](https://jwt.io/) (JSON Web Token).
 
 {% include toc.html %}
 


### PR DESCRIPTION
Applying fix from #912 to the last translation not yet affected by this change.