### PR TITLE
Fix small vocab mistake

### DIFF
--- a/lessons/basics/pipe-operator.md
+++ b/lessons/basics/pipe-operator.md
@@ -53,7 +53,7 @@ true
 
 ## Best Practices
 
-If the arity of a function is more than 1, then make sure to use parentheses. This doesn't matter much to the Elixir, but it matters to other programmers who may misinterpret your code. If we take our 3rd example, and remove the brackets from `String.ends_with?/2`, we are met with the following warning.
+If the arity of a function is more than 1, then make sure to use parentheses. This doesn't matter much to the Elixir, but it matters to other programmers who may misinterpret your code. If we take our 3rd example, and remove the parentheses from `String.ends_with?/2`, we are met with the following warning.
 
 ```shell
 iex> "elixir" |> String.ends_with? "ixir"


### PR DESCRIPTION
I believe that the author meant to use 'parentheses' instead of 'brackets' in the pipe operator lesson. Just a small change to avoid confusion.