### PR TITLE
Character list sigil output: missing backslash

### DIFF
--- a/lessons/basics/sigils.md
+++ b/lessons/basics/sigils.md
@@ -46,7 +46,7 @@ iex> ~c/2 + 7 = #{2 + 7}/
 '2 + 7 = 9'
 
 iex> ~C/2 + 7 = #{2 + 7}/
-'2 + 7 = #{2 + 7}'
+'2 + 7 = \#{2 + 7}'
 ```
 
 We can see the lowercased `~c` interpolates the calculation, whereas the uppercased `~C` sigil does not. We will see that this uppercase / lowercase sequence is a common theme throughout the built in sigils.


### PR DESCRIPTION
I noticed while executing the example commands that the output from my iex (1.4.2) has a backslash that is not present in the documentation.
[Screenshot](http://i.imgur.com/YLGv7GG.png)
Cheers.