### PR TITLE
Use self() instead of self

### DIFF
--- a/lessons/basics/testing.md
+++ b/lessons/basics/testing.md
@@ -94,7 +94,7 @@ defmodule TestReceive do
   use ExUnit.Case
 
   test "receives ping" do
-    SendingProcess.run(self)
+    SendingProcess.run(self())
     assert_received :ping
   end
 end


### PR DESCRIPTION
Running the code in this example I got the following warning:
```
warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  test/example_test.exs:20
```