### PR TITLE
Update the GenStage examples for v0.11

### DIFF
--- a/gr/lessons/advanced/gen-stage.md
+++ b/gr/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ $ cd genstage_example
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ $ touch lib/genstage_example/producer.ex
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ $ touch lib/genstage_example/producer_consumer.ex
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -159,7 +156,6 @@ $ touch lib/genstage_example/consumer.ex
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do

--- a/ko/lessons/advanced/gen-stage.md
+++ b/ko/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ $ cd genstage_example
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ $ touch lib/genstage_example/producer.ex
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ $ touch lib/genstage_example/producer_consumer.ex
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -159,7 +156,6 @@ $ touch lib/genstage_example/consumer.ex
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do

--- a/lessons/advanced/gen-stage.md
+++ b/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ Let's update our dependencies in `mix.exs` to include `gen_stage`:
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ Now we can add the code:
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ Let's update our file to look like the example code:
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -159,7 +156,6 @@ Since consumers and producer-consumers are so similar our code won't look much d
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do

--- a/pl/lessons/advanced/gen-stage.md
+++ b/pl/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ Następnie zmieńmy `mix.exs` dodając zależność do `gen_stage`:
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ I dodajmy kod:
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ Po utworzeniu pliku dodajmy kod:
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -159,7 +156,6 @@ Jako że producent-konsument i konsument są bardzo podobne, to kod nie będzie 
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do

--- a/ru/lessons/advanced/gen-stage.md
+++ b/ru/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ $ cd genstage_example
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ $ touch lib/genstage_example/producer.ex
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ $ touch lib/genstage_example/producer_consumer.ex
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -159,7 +156,6 @@ $ touch lib/genstage_example/consumer.ex
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do

--- a/vi/lessons/advanced/gen-stage.md
+++ b/vi/lessons/advanced/gen-stage.md
@@ -61,7 +61,7 @@ Sau đó thêm `gen_stage` vào các thư viện trong `mix.exs`
 ```elixir
   defp deps do
     [
-      {:gen_stage, "~> 0.7"},
+      {:gen_stage, "~> 0.11"},
     ]
   end
 ```
@@ -87,8 +87,6 @@ Sau đó thêm code vào:
 
 ```elixir
 defmodule GenstageExample.Producer do
-  alias Experimental.GenStage
-
   use GenStage
 
   def start_link(initial \\ 0) do
@@ -120,7 +118,6 @@ Ta cập nhật file cho nó giống với đoạn code bên dưới:
 
 ```elixir
 defmodule GenstageExample.ProducerConsumer  do
-  alias Experimental.GenStage
   use GenStage
 
   require Integer
@@ -160,7 +157,6 @@ Vì consumer và producer-consumer khá giống nhau nên code của chúng ta t
 
 ```elixir
 defmodule GenstageExample.Consumer do
-  alias Experimental.GenStage
   use GenStage
 
   def start_link do


### PR DESCRIPTION
This PR updates the examples in the GenStage advanced lesson. It includes a version bump for GenStage and removal of invalid code in the examples.