### PR TITLE
Update 'mnesia/create_schema' example to remove warning

### DIFF
--- a/gr/lessons/specifics/mnesia.md
+++ b/gr/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ iex(learner@elixirschool.com)> Node.self
 
 ```shell
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/id/lessons/specifics/mnesia.md
+++ b/id/lessons/specifics/mnesia.md
@@ -93,7 +93,7 @@ Sekarang setelah kita mahami dasar-dasarnya dan sudah mensetup databasenya, kita
 
 ```shell
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/ko/lessons/specifics/mnesia.md
+++ b/ko/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ iex(learner@elixirschool.com)> Node.self
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/lessons/specifics/mnesia.md
+++ b/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ Now we have the background basics out of the way and set up the database, we are
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/pl/lessons/specifics/mnesia.md
+++ b/pl/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ Mamy już podstawową wiedzę i jesteśmy na dobrej drodze do uruchomienia bazy 
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/pt/lessons/specifics/mnesia.md
+++ b/pt/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ Agora que temos o conhecimento básico e criação do banco de dados, estamos ag
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/ru/lessons/specifics/mnesia.md
+++ b/ru/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ iex(learner@elixirschool.com)> Node.self
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok

--- a/vi/lessons/specifics/mnesia.md
+++ b/vi/lessons/specifics/mnesia.md
@@ -92,7 +92,7 @@ Bây giờ chúng ta đã có kiến thức căn bản về cách thiết lập 
 
 ```elixir
 iex> alias :mnesia, as: Mnesia
-iex> Mnesia.create_schema([node])
+iex> Mnesia.create_schema([node()])
 :ok
 iex> Mnesia.start()
 :ok


### PR DESCRIPTION
This simple update to the example code will remove the following warning:

Instead of
```
iex> Mnesia.create_schema([node])
warning: variable "node" does not exist and is being expanded to "node()", please use parentheses to remove the ambiguity or change the variable name
:ok
```

this works better:
```
iex> Mnesia.create_schema([node()])
:ok
```