### PR TITLE
Fix with syntax in control structures lesson

### DIFF
--- a/bg/lessons/basics/control-structures.md
+++ b/bg/lessons/basics/control-structures.md
@@ -170,8 +170,7 @@ end
 Когато използваме `with` разполагаме с код, който е лесен за разбиране и съдържа по-малко редове:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```

--- a/bn/lessons/basics/control-structures.md
+++ b/bn/lessons/basics/control-structures.md
@@ -172,10 +172,9 @@ end
 এবার রিফ্যাক্টর করে `with` কে নিয়ে আসা যাক- 
 
 ```elixir
-with 
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 উপরিউক্ত কোডটি যেমন ছোট তেমনি বোধগম্য। 

--- a/de/lessons/basics/control-structures.md
+++ b/de/lessons/basics/control-structures.md
@@ -171,8 +171,7 @@ end
 Wenn wir `with` einführen, kommen wir zu Code, der einfach zu verstehen ist und aus weniger Zeilen Code besteht:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```

--- a/gr/lessons/basics/control-structures.md
+++ b/gr/lessons/basics/control-structures.md
@@ -171,10 +171,9 @@ end
 Όταν εισάγουμε την `with`, καταλήγουμε με κώδικα που είναι έυκολο να καταλάβουμε και έχει λιγότερες γραμμές:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 

--- a/id/lessons/basics/control-structures.md
+++ b/id/lessons/basics/control-structures.md
@@ -169,8 +169,7 @@ end
 Ketika kita menggunakan `with` kita dapati code yang mudah dipahami dan menggunakan jumlah line yang lebih sedikit:
 
 ```elixir
-with 
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```

--- a/jp/lessons/basics/control-structures.md
+++ b/jp/lessons/basics/control-structures.md
@@ -171,8 +171,7 @@ end
 `with`を導入するとコードが短く、わかりやすくなります:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -170,10 +170,9 @@ end
 `with`를 도입하면 더 짧으면서도 이해하기 쉬운 코드를 작성할 수 있습니다.
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 

--- a/lessons/basics/control-structures.md
+++ b/lessons/basics/control-structures.md
@@ -171,10 +171,9 @@ end
 When we introduce `with` we end up with code that is easy to understand and has fewer lines:
 
 ```elixir
-with 
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 

--- a/no/lessons/basics/control-structures.md
+++ b/no/lessons/basics/control-structures.md
@@ -174,9 +174,8 @@ end
 Når vi introduserer `with` til eksemplet, ender vi opp med kode som er enklere å lese, og som består av færre linjer:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 

--- a/pl/lessons/basics/control-structures.md
+++ b/pl/lessons/basics/control-structures.md
@@ -170,10 +170,9 @@ end
 Dzięki wprowadzeniu `with` nasz końcowy kod jest krótszy i łatwiejszy do zrozumienia:
 
 ```elixir
-with 
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 Elixir od wersji 1.3 pozwala też na użycie `else` w wyrażeniu `with`:

--- a/ru/lessons/basics/control-structures.md
+++ b/ru/lessons/basics/control-structures.md
@@ -170,10 +170,9 @@ end
 А теперь благодаря `with` мы в итоге получим короткий и простой для понимания код:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 Начиная с версии Elixir 1.3, конструкция `with` также начала поддерживать `else`:

--- a/vi/lessons/basics/control-structures.md
+++ b/vi/lessons/basics/control-structures.md
@@ -171,10 +171,9 @@ end
 Khi chúng ta dùng `with`, code sẽ dễ đọc hơn và có ít dòng hơn:
 
 ```elixir
-with
-  {:ok, user} <- Repo.insert(changeset),
-  {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
-  do: important_stuff(jwt, full_claims)
+with {:ok, user} <- Repo.insert(changeset),
+     {:ok, jwt, full_claims} <- Guardian.encode_and_sign(user, :token),
+     do: important_stuff(jwt, full_claims)
 ```
 
 Với Elixir 1.3, biểu thức `with` bắt đầu hỗ trợ `else`:


### PR DESCRIPTION
The first match clause must be on the same line with `with` keyword. [Docs](https://hexdocs.pm/elixir/master/Kernel.SpecialForms.html#with/1)
Otherwise compiler throws `SyntaxError: unexpectedly reached end of line. The current expression is invalid or incomplete`