### PR TITLE
Fix typo on selection language menu

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ lang: en
 
 Lessons about the Elixir programming language, inspired by Twitter's [Scala School](http://twitter.github.io/scala_school/).
 
-Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][my], [Українською][uk], [한국어][ko], [L'italiano][it], [Deutsch](de), [বাংলা](bn) and other.
+Available in [Việt ngữ][vi], [汉语][cn], [Español][es], [Slovenčina][sk], [日本語][jp], [Polski][pl], [Português][pt], [Русском][ru], [Bahasa Melayu][my], [Українською][uk], [한국어][ko], [Italiano][it], [Deutsch](de), [বাংলা](bn) and other.
 
   [cn]: /cn/
   [es]: /es/


### PR DESCRIPTION
Italiano is more correct than: L'Italiano