### PR TITLE
Improve headers usability

### DIFF
--- a/_assets/javascripts/app.js
+++ b/_assets/javascripts/app.js
@@ -38,8 +38,9 @@ $(function() {
     listType: 'ul',
     title: '',
     headers: 'h1, h2, h3:not([id="social"]), h4, h5, h6',
-    noBackToTopLinks: true,
-    minimumHeaders: 0
+    noBackToTopLinks: false,
+    minimumHeaders: 0,
+    backToTopClasses: 'fa fa-chevron-up back-to-top'
   });
   $('.version-info').click(show_vcs_history);
 });

--- a/_assets/javascripts/toc.js
+++ b/_assets/javascripts/toc.js
@@ -9,9 +9,11 @@
       listType: 'ol', // values: [ol|ul]
       showEffect: 'show', // values: [show|slideDown|fadeIn|none]
       showSpeed: 'slow', // set to 0 to deactivate effect
-      classes: { list: '',
-                 item: ''
-               }
+      classes: {
+        list: '',
+        item: ''
+      },
+      backToTopClasses: 'icon-arrow-up back-to-top'
     },
     settings = $.extend(defaults, options);
 
@@ -20,9 +22,10 @@
         return '%' + c.charCodeAt(0).toString(16);
       });
     }
-    
+
     function createLink (header) {
-      return "<a href='#" + fixedEncodeURIComponent(header.id) + "'>" + header.innerHTML + "</a>";
+      var innerText = (header.textContent === undefined) ? header.innerText : header.textContent;
+      return "<a href='#" + fixedEncodeURIComponent(header.id) + "'>" + innerText + "</a>";
     }
 
     var headers = $(settings.headers).filter(function() {
@@ -50,8 +53,7 @@
     };
 
     var get_level = function(ele) { return parseInt(ele.nodeName.replace("H", ""), 10); };
-    var highest_level = headers.map(function(_, ele) { return get_level(ele); }).get().sort()[0];
-    var return_to_top = '<i class="icon-arrow-up back-to-top"> </i>';
+    var return_to_top = '<i class="' + settings.backToTopClasses + '"> </i>';
 
     var level = get_level(headers[0]),
       this_level,
@@ -64,13 +66,13 @@
     .addClass('clickable-header')
     .each(function(_, header) {
       this_level = get_level(header);
-      if (!settings.noBackToTopLinks && this_level === highest_level) {
-        $(header).addClass('top-level-header').after(return_to_top);
+      if (!settings.noBackToTopLinks) {
+        $(header).after(return_to_top);
       }
       if (this_level === level) // same level as before; same indenting
         html += "<li class=\"" + settings.classes.item + "\">" + createLink(header);
       else if (this_level <= level){ // higher level than before; end parent ol
-        for(i = this_level; i < level; i++) {
+        for(var i = this_level; i < level; i++) {
           html += "</li></"+settings.listType+">"
         }
         html += "<li class=\"" + settings.classes.item + "\">" + createLink(header);

--- a/_assets/stylesheets/custom.scss
+++ b/_assets/stylesheets/custom.scss
@@ -1,20 +1,22 @@
 /*
  * Custom Theme Classes
  */
+$header-color: #F07E6B;
+$anchor-color: #4A365F;
 
 .theme-custom-purple .sidebar {
   background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAALUlEQVQYV2P0Mov/z0AEYKRY4f///58zMjJKwiyj3ER0Z9PIRHSHYwst6lsNAMs/GrcD9Fh5AAAAAElFTkSuQmCC) repeat;
 }
 .theme-custom-purple .content a,
 .theme-custom-purple .related-posts li a:hover {
-  color: #4A365F;
+  color: $anchor-color;
 }
 .theme-custom-purple .content a {
   text-decoration: underline;
 }
 
 h2 {
- color: #F07E6B;
+ color: $header-color;
 }
 
 .sidebar-lesson {
@@ -33,6 +35,27 @@ a.sidebar-lesson:focus {
 .page-title {
   display: inline-flex;
   align-items: center;
+}
+
+i.back-to-top {
+  display: inline;
+  cursor: pointer;
+  padding-left: 1em;
+  color: $anchor-color;
+
+  &::after {
+    content: '\A';
+    white-space: pre;
+  }
+}
+
+.theme-custom-purple .content .clickable-header {
+  display: inline-block;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 /*
@@ -76,7 +99,7 @@ a.sidebar-lesson:focus {
     font-weight: bold;
     line-height: 1.25;
     font-size: 1.5rem;
-    color: #F07E6B;
+    color: $header-color;
   }
 
   i {

--- a/ko/lessons/basics/basics.md
+++ b/ko/lessons/basics/basics.md
@@ -20,7 +20,7 @@ elixir-lang.org 홈페이지의 [Installing Elixir](http://elixir-lang.org/insta
 Elixir를 설치하고 나서 어떤 버전이 설치되었는지 손쉽게 확인할 수 있습니다.
 
     % elixir -v
-    Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}  [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+    Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}]  [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
     Elixir {{ site.elixir.version }}
 


### PR DESCRIPTION
This PR turns the headers into anchors and adds the `back-to-top` icons next to them. 
In order to achieve this it includes the latest version of the [TOC script](https://github.com/ghiculescu/jekyll-table-of-contents) with locally added ability to customize the `back-to-top` icon classes and several relevant SCSS changes.