### PR TITLE
Fix syntax warning for Greeter module under 'Guards' section in Basics/Functions lesson

### DIFF
--- a/bg/lessons/basics/functions.md
+++ b/bg/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/bn/lessons/basics/functions.md
+++ b/bn/lessons/basics/functions.md
@@ -153,7 +153,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/cn/lessons/basics/functions.md
+++ b/cn/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/de/lessons/basics/functions.md
+++ b/de/lessons/basics/functions.md
@@ -150,7 +150,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/es/lessons/basics/functions.md
+++ b/es/lessons/basics/functions.md
@@ -127,7 +127,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/fr/lessons/basics/functions.md
+++ b/fr/lessons/basics/functions.md
@@ -135,7 +135,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/gr/lessons/basics/functions.md
+++ b/gr/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Γειά, "

--- a/id/lessons/basics/functions.md
+++ b/id/lessons/basics/functions.md
@@ -127,7 +127,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/it/lessons/basics/functions.md
+++ b/it/lessons/basics/functions.md
@@ -127,7 +127,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/jp/lessons/basics/functions.md
+++ b/jp/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/ko/lessons/basics/functions.md
+++ b/ko/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/lessons/basics/functions.md
+++ b/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/my/lessons/basics/functions.md
+++ b/my/lessons/basics/functions.md
@@ -128,7 +128,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/pl/lessons/basics/functions.md
+++ b/pl/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/pt/lessons/basics/functions.md
+++ b/pt/lessons/basics/functions.md
@@ -126,7 +126,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/ru/lessons/basics/functions.md
+++ b/ru/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/sk/lessons/basics/functions.md
+++ b/sk/lessons/basics/functions.md
@@ -133,7 +133,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Hello, "

--- a/vi/lessons/basics/functions.md
+++ b/vi/lessons/basics/functions.md
@@ -149,7 +149,7 @@ defmodule Greeter do
   end
 
   def hello(name) when is_binary(name) do
-    phrase <> name
+    phrase() <> name
   end
 
   defp phrase, do: "Chào "


### PR DESCRIPTION
Fixes the following warning shown when executing this example in IEx:

```
warning: variable "phrase" does not exist and is being expanded to "phrase()", please use parentheses to remove the ambiguity or change the variable name
```

Follows Elixir Style Guide [here](https://github.com/christopheradams/elixir_style_guide#parentheses), recommending that functions without arguments should not have parentheses. Instead, use parentheses in function invocation.

Fixes #985

References #986