### PR TITLE
[KO] Update translation on exist documents

### DIFF
--- a/ko/lessons/advanced/concurrency.md
+++ b/ko/lessons/advanced/concurrency.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 동시성
 category: advanced

--- a/ko/lessons/advanced/erlang.md
+++ b/ko/lessons/advanced/erlang.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Erlang 상호 운용
 category: advanced

--- a/ko/lessons/advanced/error-handling.md
+++ b/ko/lessons/advanced/error-handling.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 에러 처리
 category: advanced

--- a/ko/lessons/advanced/escripts.md
+++ b/ko/lessons/advanced/escripts.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 실행 파일
 category: advanced

--- a/ko/lessons/advanced/metaprogramming.md
+++ b/ko/lessons/advanced/metaprogramming.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 메타 프로그래밍
 category: advanced

--- a/ko/lessons/advanced/otp-concurrency.md
+++ b/ko/lessons/advanced/otp-concurrency.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: OTP 동시성
 category: advanced

--- a/ko/lessons/advanced/otp-supervisors.md
+++ b/ko/lessons/advanced/otp-supervisors.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: OTP 슈퍼바이저
 category: advanced

--- a/ko/lessons/advanced/umbrella-projects.md
+++ b/ko/lessons/advanced/umbrella-projects.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 엄브렐라 프로젝트
 category: advanced

--- a/ko/lessons/basics/basics.md
+++ b/ko/lessons/basics/basics.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 기본
 category: basics

--- a/ko/lessons/basics/collections.md
+++ b/ko/lessons/basics/collections.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 컬렉션
 category: basics

--- a/ko/lessons/basics/comprehensions.md
+++ b/ko/lessons/basics/comprehensions.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Comprehensions
 category: basics

--- a/ko/lessons/basics/control-structures.md
+++ b/ko/lessons/basics/control-structures.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 제어 구조
 category: basics

--- a/ko/lessons/basics/documentation.md
+++ b/ko/lessons/basics/documentation.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 문서화
 category: basics

--- a/ko/lessons/basics/enum.md
+++ b/ko/lessons/basics/enum.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Enum
 category: basics

--- a/ko/lessons/basics/functions.md
+++ b/ko/lessons/basics/functions.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 함수
 category: basics

--- a/ko/lessons/basics/mix-tasks.md
+++ b/ko/lessons/basics/mix-tasks.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 커스텀 Mix 태스크
 category: basics

--- a/ko/lessons/basics/mix.md
+++ b/ko/lessons/basics/mix.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Mix
 category: basics

--- a/ko/lessons/basics/modules.md
+++ b/ko/lessons/basics/modules.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 모듈
 category: basics

--- a/ko/lessons/basics/pattern-matching.md
+++ b/ko/lessons/basics/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 패턴 매칭
 category: basics

--- a/ko/lessons/basics/pipe-operator.md
+++ b/ko/lessons/basics/pipe-operator.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 파이프 연산자
 category: basics

--- a/ko/lessons/basics/sigils.md
+++ b/ko/lessons/basics/sigils.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 시길
 category: basics

--- a/ko/lessons/basics/strings.md
+++ b/ko/lessons/basics/strings.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 문자열
 category: basics

--- a/ko/lessons/basics/testing.md
+++ b/ko/lessons/basics/testing.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: 테스트
 category: basics

--- a/ko/lessons/libraries/guardian.md
+++ b/ko/lessons/libraries/guardian.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Guardian (Basics)
 category: libraries
@@ -191,9 +191,9 @@ defmodule MyApp.MyController do
 end
 ```
 
-`Guardian.Phoenix.Controller` 모듈을 사용하려면, 패턴매칭에 사용할 액션에 인자를 두개 추가할 필요가 있습니다. `EnsureAuthentication`을 사용하지 않으면 nil 유저나 클레임을 받을 수 있다는 걸 기억하세요.
+`Guardian.Phoenix.Controller` 모듈을 사용하려면, 패턴매칭에 사용할 액션에 인자를 두개 추가할 필요가 있습니다. `EnsureAuthenticated`을 사용하지 않으면 nil 유저나 클레임을 받을 수 있다는 걸 기억하세요.
 
-더 유연하고 장황한 다른 방법은 plug 핼퍼를 사용하는 것입니다.
+더 유연하고 장황한 다른 방법은 Plug 헬퍼를 사용하는 것입니다.
 
 ```elixir
 defmodule MyApp.MyController do

--- a/ko/lessons/libraries/poolboy.md
+++ b/ko/lessons/libraries/poolboy.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Poolboy
 category: libraries

--- a/ko/lessons/specifics/ecto.md
+++ b/ko/lessons/specifics/ecto.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Ecto
 category: specifics
@@ -17,8 +17,8 @@ Ecto는 공식적인 Elixir 프로젝트로 데이터베이스를 감싸는 부�
 
 ```elixir
 defp deps do
-  [{:ecto, "~> 1.0"},
-   {:postgrex, ">= 0.0.0"}]
+  [{:ecto, "~> 2.1.4"},
+   {:postgrex, ">= 0.13.2"}]
 end
 ```
 

--- a/ko/lessons/specifics/eex.md
+++ b/ko/lessons/specifics/eex.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Embedded Elixir (EEx)
 category: specifics

--- a/ko/lessons/specifics/ets.md
+++ b/ko/lessons/specifics/ets.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Erlang Term Storage (ETS)
 category: specifics

--- a/ko/lessons/specifics/mnesia.md
+++ b/ko/lessons/specifics/mnesia.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.0.0
 layout: page
 title: Mnesia
 category: specifics

--- a/ko/lessons/specifics/plug.md
+++ b/ko/lessons/specifics/plug.md
@@ -1,5 +1,5 @@
 ---
-version: 0.9.0
+version: 1.1.0
 layout: page
 title: Plug
 category: specifics
@@ -11,12 +11,23 @@ Ruby를 잘 알고 계신다면 Plug는 여러 부분에서 Sinatra의 영향을
 Plug는 Web 애플리케이션을 위한 명세와 Web 서버를 위한 어댑터를 제공합니다.
 Elixir 코어의 일부가 아닌, Elixir의 공식 프로젝트입니다.
 
-최소한의 플러그 기반의 웹 애플리케이션만드는 것으로 시작해봅시다.
-그러고나면, 플러그의 라우터와 기존의 웹 애플리케이션에 플러그를 추가하는 법을 알게 될 것입니다.
+작은 Plug 기반의 웹 애플리케이션을 만드는 것으로 시작해봅시다.
+그러고나면, Plug의 라우터와 기존의 웹 애플리케이션에 Plug를 추가하는 법을 알게 될 것입니다.
 
 {% include toc.html %}
 
-## 설치하기
+## 시작하기 전에
+
+이 강의는 Elixir와 `mix`가 설치되어 있다고 가정합니다.
+
+만약 새 프로젝트를 만든적이 없다면 다음의 명령과 같이 입력하세요.
+
+```shell
+mix new example
+cd example
+```
+
+## 의존성
 
 mix를 사용하여 간단하게 설치할 수 있습니다.
 Plug를 설치하기 위해서는 `mix.exs`에 두 가지 작은 수정을 해야 합니다.
@@ -40,9 +51,6 @@ $ mix deps.get
 Plug를 만들기 위해서는 Plug의 명세를 알고 그것을 올바르게 따를 필요가 있습니다.
 기쁘게도 필요한 것은 단 두 개의 함수, `init/1`과 `call/2` 뿐입니다.
 
-`init/1` 함수는 Plug의 옵션을 초기화하기 위해서 사용되며, 그 옵션은 `call/2` 함수의 두 번째 인자로 넘겨집니다.
-`call/2` 함수는 초기화된 옵션과 함께 `%Plug.Conn`를 첫 번째 인자로 하고, 커넥션을 돌려줄 것이라고 가정하고 있습니다.
-
 다음은 "Hello World!"를 돌려주는 간단한 Plug입니다.
 
 ```elixir
@@ -60,6 +68,17 @@ end
 ```
 
 파일을 `lib/example/hello_world_plug.ex`에 저장합니다.
+
+`init/1` 함수는 Plug의 옵션을 초기화할 때 사용됩니다. 이는 슈퍼바이저 트리에
+의해서 호출되며, 이는 다듬 장에서 설명합니다. 지금은 빈 리스트이므로 무시합시다.
+
+`init/1`에 의해서 반환되는 값은 최종적으로 `call/2`의 두번째 인자로 넘겨집니다.
+
+`call/2` 함수는 Cowboy로부터 넘어온 매 새로운 요청에 대해서 호출됩니다.
+이는 `%Plug.Conn{}` 커넥션 구조체를 첫번째 인자로 받으며,
+`%Plug.Conn{}` 커넥션 구조체를 반환해야 합니다.
+
+## 프로젝트의 애플리케이션 모듈 설정하기
 
 처음부터 Plug 애플리케이션을 만들었기 떄문에, 애플리케이션 모듈을 정의해야 합니다.
 `lib/example.ex`를 수정해 시작하고 Cowboy를 관리하도록 합시다.
@@ -83,10 +102,13 @@ end
 
 이는 Cowboy를 감독하고, `HelloWorldPlug`도 감독합니다.
 
-이제, `mix.exs`의 `application` 부분에 두 가지가 필요합니다.
+`Plug.Adapters.Cowboy.child_spec/4` 호출에서 세번째 인수가 `Example.HelloWorldPlug.init/1`로 넘겨집니다.
+
+여기서 끝이 아닙니다. `mix.exs`을 다시 열고, `application` 함수를 찾으세요.
+지금은 두 가지가 필요합니다.
 1) 시작해야하는 의존 애플리케이션 (`cowboy`,`logger`,`plug`) 목록과
 2) 이 애플리케이션을 위한 설정, 이것도 자동으로 시작되어야합니다.
-이를 위해 `mix.exs`의 `application` 부분을 업데이트 해 봅시다.
+이를 위해 함수를 업데이트 해 봅시다.
 
 ```elixir
 def application do
@@ -97,7 +119,7 @@ def application do
 end
 ```
 
-이제 최소한의 플러그인 기반 웹 서버를 사용해 볼 준비가되었습니다.
+이제 최소한의 Plug 기반 웹 서버를 사용해 볼 준비가 되었습니다.
 커맨드 라인에서 다음을 실행하십시오.
 
 ```shell
@@ -114,7 +136,7 @@ Hello World!
 ## Plug.Router
 
 웹 사이트 또는 REST API와 같은 대부분의 애플리케이션의 경우 라우터가 다른 경로 및 HTTP 메소드에 대한 요청을 다른 처리기로 라우팅해야합니다.
-`Plug`는 이런 일을 할 수있는 라우터를 제공합니다. 봐서 알 수 있듯이, Elixir에서는 Plug만으로 Sinatra가 하던 일을 할 수 때문에 Sinatra와 같은 프레임 워크가 필요하지 않습니다.
+`Plug`는 이런 일을 할 수 있는 라우터를 제공합니다. 봐서 알 수 있듯이, Elixir에서는 Plug만으로 Sinatra가 하던 일을 할 수 때문에 Sinatra와 같은 프레임워크가 필요하지 않습니다.
 
 시작해봅시다. `lib/example/router.ex` 파일을 만들어 다음 내용을 안에 넣으세요.
 
@@ -131,11 +153,11 @@ end
 ```
 
 이것은 최소한의 라우터이지만 코드는 꽤 자명합니다.
-`use plug.Router`를 통해 매크로를 넣어 `match`와`dispatch` 두 가지 플러그인을 설정했습니다.
-루트에 대한 GET 요청을 처리하는 라우트와 다른 모든 요청과 매치해 404를 반환하는 두 번째 라우트가 정의되어 있습니다.
+`use plug.Router`를 통해 매크로를 넣어 `:match`와 `:dispatch`라는 내장 Plug를 설정했습니다.
+루트에 대한 GET 요청을 처리하는 최상위 라우트와 다른 모든 요청과 매치해 404 메시지를 반환하는 두 번째 라우트가 정의되어 있습니다.
 
-다시 `lib/example.ex`로 돌아가서, `Example.Router`를 웹 서버 수퍼바이저 트리에 넣어 주어야 합니다.
-`Example.HelloWorldPlug` plug를 새로운 라우터로 교채해 봅시다.
+다시 `lib/example.ex`로 돌아가서, `Example.Router`를 웹 서버 슈퍼바이저 트리에 넣어 주어야 합니다.
+`Example.HelloWorldPlug` plug를 새로운 라우터로 교체해 봅시다.
 
 ```elixir
 def start(_type, _args) do
@@ -147,7 +169,7 @@ def start(_type, _args) do
 end
 ```
 
-서버를 재시작해 봅시다. 실행 되고 있다면 (`Ctrl + C`를 두 번 눌러) 이전 서버를 중지하세요.
+서버를 재시작해 봅시다. 이전 서버가 실행중이라면 (`Ctrl + C`를 두 번 눌러) 중지하세요.
 
 이제 췝브라우저에서 `localhost:8080`로 이동하세요.
 `Welcome`이 출력될 것 입니다.
@@ -156,9 +178,9 @@ end
 
 ## 다른 Plug 추가하기
 
-일반적인 요청을 다루는 로직을 처리할 때, 모든 요청이나 요청의 일부를 가로 채기 위해 Plug를 만드는 것이 일반적입니다.
+일반적인 요청을 다루는 로직을 처리할 때, 모든 요청이나 요청의 일부를 가로채기 위해 Plug를 만드는 것이 일반적입니다.
 
-이 예제에서 요청에 필요한 매개 변수가 있는지 확인하기 위해 Plug를 만듭니다.
+이 예제에서 요청에 필요한 매개 변수가 있는지 확인하기 위한 Plug를 만듭니다.
 Plug에서 검증을 구현하면 유효한 요청 만 애플리케이션에 적용될 수 있습니다.
 Plug는 `:paths`와 `:fields` 옵션으로 초기화 되어야 합니다.
 이것은 로직을 적용 할 경로(paths)와 필요한 필드(fields)를 나타냅니다.
@@ -166,7 +188,7 @@ Plug는 `:paths`와 `:fields` 옵션으로 초기화 되어야 합니다.
 _Note_ : Plug는 모든 요청에 적용되므로 요청을 필터링해 일부에만 로직을 적용할 필요가 있습니다.
 요청을 무시하려면 그냥 연결을 넘겨주면 됩니다.
 
-완성 된 Plug를보고 어떻게 작동하는지 설명할께요.
+완성 된 Plug를 보고 어떻게 작동하는지 설명합니다.
 `lib/plug/verify_request.ex`에 만들겠습니다.
 
 ```elixir
@@ -209,7 +231,7 @@ end
 만약 부족한 필드가 있는 경우에는 `Incompleterequesterror`를 발생시킵니다.
 
 `/upload`에 대한 모든 요청에 `"content"` 와`"mimetype"` 둘 다 있는지 확인하기 위해 Plug를 설정했습니다.
-확인 이 된 경우에만 라우트 코드가 실행됩니다.
+확인된 경우에만 라우트 코드가 실행됩니다.
 
 그런 다음, 라우터에게 새 Plug를 알려줄 필요가 있습니다.
 `lib/example/router.ex`를 열어 다음과 같이 수정합니다.
@@ -243,14 +265,14 @@ end
 
 ```elixir
 def application do
-  [applications: [:cowboy, :plug],
+  [applications: [:cowboy, :logger, :plug],
    mod: {Example, []},
    env: [cowboy_port: 8080]]
 end
 ```
 
 애플리케이션은 `mod : {Example, []}`으로 설정합니다.
-`cowboy`와 `plug` 애플리케이션을 시작하는 것도 알 수 있습니다.
+`cowboy`, `logger`와 `plug` 애플리케이션을 시작하는 것도 알 수 있습니다.
 
 다음으로 `lib/example.ex`를 업데이트하여 포트 설정 값을 읽어서 카우보이에게 넘겨 줄 필요가 있습니다.
 
@@ -288,7 +310,8 @@ $ mix run --no-halt
 
 ## Plug의 테스트
 
-Plug의 테스트는 `Plug.Test` 덕분에 무척 간단합니다. 테스트를 간편하게 만들어주는 편리한 함수가 다수 포함되어 있습니다.
+Plug의 테스트는 `Plug.Test` 덕분에 무척 간단합니다.
+테스트를 간편하게 만들어주는 편리한 함수가 다수 포함되어 있습니다.
 
 라우터의 테스트를 이해할 수 있는지 확인해보세요.
 


### PR DESCRIPTION
Changed:

- bump up version
- Use `Plug` instead of `플러그` via all translations

Remained work:

Totally not translated below.

- iex-helpers.md
- protocols.md
- debugging.md

I will translate these until next week... or is there someone to help?

@Dalgona, @malkoG, @devleoper, @marocchino  review please.

used diff: `git diff 65e4a61..dc9ab42 --word-diff -- lessons/`

related: #1043