### PR TITLE
Use the Elixir version placeholder where it was missing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -148,7 +148,7 @@ sitemap:
   priority_name: 'priority'
 
 elixir:
-  version: 1.4.0
+  version: 1.4.4
 
 erlang:
   OTP: 19

--- a/id/lessons/advanced/umbrella-projects.md
+++ b/id/lessons/advanced/umbrella-projects.md
@@ -205,7 +205,7 @@ Consolidated String.Chars
 Consolidated Enumerable
 Consolidated IEx.Info
 Consolidated Inspect
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 
 iex> Datasets.hello
 Hello, I'm the datasets

--- a/id/lessons/basics/basics.md
+++ b/id/lessons/basics/basics.md
@@ -25,7 +25,7 @@ Untuk memulai, kita jalankan `iex`:
 
 	Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Tipe dasar

--- a/id/lessons/specifics/mnesia.md
+++ b/id/lessons/specifics/mnesia.md
@@ -80,7 +80,7 @@ $ iex --name learner@elixirschool.com
 
 Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 iex(learner@elixirschool.com)> Node.self
 :"learner@elixirschool.com"
 ```

--- a/no/lessons/basics/basics.md
+++ b/no/lessons/basics/basics.md
@@ -25,7 +25,7 @@ For å starte IEx skriver vi `iex` i terminalvinduet:
 
 	Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-	Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+	Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
 	iex>
 
 ## Grunnleggende Typer


### PR DESCRIPTION
There were some places where the Elixir version in `iex` examples was hardcoded.
Also [1.4.4](https://github.com/elixir-lang/elixir/releases) is the latest version now.