### PR TITLE
Rename the "gems" config key to "plugins"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ author:
   twitter: doomspork
   github: doomspork
 
-gems:
+plugins:
   - jekyll-assets
   - jekyll-redirect-from
   - jekyll-sitemap


### PR DESCRIPTION
Recently we have updated Jekyll to resolve #1134. After the [latest major update](https://github.com/jekyll/jekyll/releases/tag/v3.5.0) Jekyll [started offering a replacement for the `gems` config key](https://github.com/jekyll/jekyll/pull/5130). So without this proposed change a deprecation warning would be displayed during every build:
>Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.