### PR TITLE
Bump Elixir and OTP versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,11 +41,11 @@ sitemap:
   priority_name: 'priority'
 
 elixir:
-  version: 1.4.4
+  version: 1.5.0
 
 erlang:
-  OTP: 19
-  erts: 8.0.2
+  OTP: 20
+  erts: 9.0
 
 defaults:
   -


### PR DESCRIPTION
[1.5.0 was released yesterday](https://github.com/elixir-lang/elixir/releases/tag/v1.5.0).