### PR TITLE
Fix test/*.exs comments showing file paths.

### DIFF
--- a/en/lessons/advanced/otp-distribution.md
+++ b/en/lessons/advanced/otp-distribution.md
@@ -336,7 +336,7 @@ iex(moebi@localhost)> hi
 Let's start by writing a simple test for our `send_message` function.
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -375,7 +375,7 @@ Let's take a look at the first approach.
 We'll add an `ExUnit` tag to this test:
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -390,6 +390,7 @@ end
 And we'll add some conditional logic to our test helper to exclude tests with such tags if the tests are _not_ running on a named node.
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/es/lessons/advanced/otp-distribution.md
+++ b/es/lessons/advanced/otp-distribution.md
@@ -337,7 +337,7 @@ iex(moebi@localhost)> hi
 Vamos a empezar a escribir una prueba simple para nuestra función `send_message`.
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -379,7 +379,7 @@ Vamos a revisar el primer enfoque.
 Agregaremos una etiqueta `ExUnit` a esta prueba:
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -394,6 +394,7 @@ end
 Y agregaremos lógica condicional a nuestro *helper* de pruebas para excluir pruebas con tales etiquetas si las pruebas no están corriendo en un nodo con nombre.
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/gr/lessons/advanced/otp-distribution.md
+++ b/gr/lessons/advanced/otp-distribution.md
@@ -336,7 +336,7 @@ iex(moebi@localhost)> hi
 Ας ξεκινήσουμε γράφοντας μια απλή δοκιμή για τη συνάρτησή μας `send_message`.
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -375,7 +375,7 @@ end
 Θα προσθέσουμε μια ετικέτα `ExUnit` σε αυτή τη δοκιμή:
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -390,6 +390,7 @@ end
 Και θα προσθέσουμε μια λογική συνθήκη στο βοηθό δοκιμών μας για να εξαιρούμε δοκιμές με αυτή την ετικέτα αν οι δοκιμές _δεν_ τρέχουν σε ονομασμένο κόμβο.
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/ja/lessons/advanced/otp-distribution.md
+++ b/ja/lessons/advanced/otp-distribution.md
@@ -339,7 +339,7 @@ iex(moebi@localhost)> hi
 `send_message` 関数の簡単なテストを書いてみましょう。
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -381,7 +381,7 @@ end
 このテストに `ExUnit` タグを追加します:
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -396,6 +396,7 @@ end
 そして、テストが名前付きノードで実行 _されていない_ 場合にそのタグを持つテストを除外するため、条件分岐ロジックをテストヘルパーに追加します。
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/pt/lessons/advanced/otp-distribution.md
+++ b/pt/lessons/advanced/otp-distribution.md
@@ -335,7 +335,7 @@ iex(moebi@localhost)> hi
 Vamos começar escrevendo um simples teste para nossa função `send_message`.
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -377,7 +377,7 @@ Vamos dar uma olhada na primeira abordagem.
 Nós vamos adicionar uma tag `ExUnit` tag nesse teste:
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -392,6 +392,7 @@ end
 E vamos adicionar alguma lógica condicional ao nosso helper de teste para excluir testes com tais tags se os testes _não_ estão executando em um nó de processamento nomeado.
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/zh-hans/lessons/advanced/otp-distribution.md
+++ b/zh-hans/lessons/advanced/otp-distribution.md
@@ -314,7 +314,7 @@ iex(moebi@localhost)> hi
 让我们来给我们的 `send_message` 函数编写一个简单的测试用例吧。
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -354,7 +354,7 @@ end
 我们需要添加一个 `ExUnit` tag 到测试用例之上：
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -369,6 +369,7 @@ end
 然后，我们就可以在测试的 helper 模块添加一些条件逻辑，使得那些拥有特定标签的测试用例，当不是运行在一个命名的节点的时侯，被排除在外。
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 

--- a/zh-hant/lessons/advanced/otp-distribution.md
+++ b/zh-hant/lessons/advanced/otp-distribution.md
@@ -337,7 +337,7 @@ iex(moebi@localhost)> hi
 現在從為 `send_message` 函數編寫一個簡單的測試開始。
 
 ```elixir
-# test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -379,7 +379,7 @@ end
 現在將在此測試中加入一個 `ExUnit` 標籤：
 
 ```elixir
-#test/chat_test.ex
+# test/chat_test.exs
 defmodule ChatTest do
   use ExUnit.Case, async: true
   doctest Chat
@@ -394,6 +394,7 @@ end
 如果測試 _不是_ 在命名 node 上執行，將在測試 helper 加入一些條件邏輯，以排除帶有此類標籤的測試。
 
 ```elixir
+# test/test_helper.exs
 exclude =
   if Node.alive?, do: [], else: [distributed: true]
 


### PR DESCRIPTION
 * `# test/chat_test.ex` → `# test/chat_test.exs`
 * add `# test/test_helper.exs`