### PR TITLE
CI should run for all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - opened
       - reopened
       - synchronize
-  push:
-    branches:
-      - master
 
 jobs:
   Build:


### PR DESCRIPTION
Right now the GitHub Actions only run on master. We need them to run on PRs too to make sure they won't break master.