### PR TITLE
[PT] Fixing empty excerpts

### DIFF
--- a/lessons/pt/ecto/querying_basics.md
+++ b/lessons/pt/ecto/querying_basics.md
@@ -2,7 +2,6 @@
   version: "1.2.0",
   title: "Consultas",
   excerpt: """
-  
   """
 }
 ---

--- a/lessons/pt/misc/nerves.md
+++ b/lessons/pt/misc/nerves.md
@@ -2,7 +2,6 @@
   version: "1.1.2",
   title: "Nerves",
   excerpt: """
-
   """
 }
 ---


### PR DESCRIPTION
The pages were showing the wrong details in case of an empty excerpt:
![Screenshot from 2021-10-08 07-48-00](https://user-images.githubusercontent.com/350841/136544286-fee5aee9-b02f-46ac-8942-28de62ac6f15.png)

Fixed to be:
![Screenshot from 2021-10-08 07-47-53](https://user-images.githubusercontent.com/350841/136544301-e3a040d8-2f2b-486d-a554-543ddc19b788.png)
)
