### PR TITLE
[PT] bump Enum lesson to 1.8.0

### DIFF
--- a/lessons/pt/basics/enum.md
+++ b/lessons/pt/basics/enum.md
@@ -1,5 +1,5 @@
 %{
-  version: "1.7.0",
+  version: "1.8.0",
   title: "Enum",
   excerpt: """
   Um conjunto de algoritmos para fazer enumeração em coleções.


### PR DESCRIPTION
I saw in the Translation report that the Portuguese version of enum lesson is not up to date with the English version, but the only difference is actually the number of the version itself. There are no other differences in the doc.