### PR TITLE
Remove typo ("째") in Korean documentation

### DIFF
--- a/lessons/ko/basics/pattern_matching.md
+++ b/lessons/ko/basics/pattern_matching.md
@@ -88,7 +88,7 @@ iex> %{^key => value} = %{:hello => "world"}
 iex> greeting = "Hello"
 "Hello"
 iex> greet = fn
-...>째   (^greeting, name) -> "Hi #{name}"
+...>   (^greeting, name) -> "Hi #{name}"
 ...>   (greeting, name) -> "#{greeting}, #{name}"
 ...> end
 #Function<12.54118792/2 in :erl_eval.expr/5>


### PR DESCRIPTION
I noticed that the Korean documentation mistakenly included the word "째" in the code example. The character "째" should not appear in this context.